### PR TITLE
Fix charm paths in publish action

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,8 +20,8 @@ jobs:
       fail-fast: false
       matrix:
         charm-path:
-          - istio-pilot
-            istio-gateway
+          - charms/istio-pilot
+            charms/istio-gateway
     steps:
       - uses: actions/checkout@v2
       - uses: canonical/charmhub-upload-action@0.2.0


### PR DESCRIPTION
Fix charm paths in publihs action which were overlooked in the code
review of the previous PR.