### PR TITLE
change track/1.5 istio-ingressgateway charm name

### DIFF
--- a/charms/istio-ingressgateway/metadata.yaml
+++ b/charms/istio-ingressgateway/metadata.yaml
@@ -1,4 +1,4 @@
-name: istio-ingressgateway
+name: istio-gateway
 display-name: Istio Ingress Gateway
 summary: Connect, secure, control, and observe services.
 description: |


### PR DESCRIPTION
The charm for `istio-ingressgateway` in the main track was renamed `istio-gateway`.  This commit backports that change to the track/1.5 branch to ensure the old version publishes to the same charm.

This should not be merged until [this track creation request](https://portal.support.canonical.com/staff/s/case/5004K00000E7IgaQAF/create-tracks-in-charmhub-for-kubeflow-team) is completed.