### PR TITLE
Add juju-min-version metadata

### DIFF
--- a/charms/istio-ingressgateway/metadata.yaml
+++ b/charms/istio-ingressgateway/metadata.yaml
@@ -24,6 +24,7 @@ description: |
 maintainers: [Juju Developers <juju@lists.ubuntu.com>]
 tags: [service-mesh, ingress]
 series: [kubernetes]
+min-juju-version: "2.9.0"
 resources:
   oci-image:
     type: oci-image

--- a/charms/istio-ingressgateway/metadata.yaml
+++ b/charms/istio-ingressgateway/metadata.yaml
@@ -24,7 +24,6 @@ description: |
 maintainers: [Juju Developers <juju@lists.ubuntu.com>]
 tags: [service-mesh, ingress]
 series: [kubernetes]
-min-juju-version: "2.9.0"
 resources:
   oci-image:
     type: oci-image
@@ -42,4 +41,4 @@ requires:
     interface: k8s-service
     schema: https://raw.githubusercontent.com/canonical/operator-schemas/master/k8s-service.yaml
     versions: [v1]
-min-juju-version: 2.8-beta1
+min-juju-version: "2.9.0"

--- a/charms/istio-pilot/metadata.yaml
+++ b/charms/istio-pilot/metadata.yaml
@@ -24,7 +24,6 @@ description: |
 maintainers: [Juju Developers <juju@lists.ubuntu.com>]
 tags: [service-mesh]
 series: [kubernetes]
-min-juju-version: "2.9.0"
 resources:
   oci-image:
     type: oci-image
@@ -44,4 +43,4 @@ provides:
     interface: ingress-auth
     schema: https://raw.githubusercontent.com/canonical/operator-schemas/service-mesh-schemas/ingress-auth.yaml
     versions: [v1]
-min-juju-version: 2.8-beta1
+min-juju-version: "2.9.0"

--- a/charms/istio-pilot/metadata.yaml
+++ b/charms/istio-pilot/metadata.yaml
@@ -24,6 +24,7 @@ description: |
 maintainers: [Juju Developers <juju@lists.ubuntu.com>]
 tags: [service-mesh]
 series: [kubernetes]
+min-juju-version: "2.9.0"
 resources:
   oci-image:
     type: oci-image


### PR DESCRIPTION
This PR addresses https://github.com/canonical/bundle-kubeflow/issues/425 where a PVC is created per operator, adding the `min-juju-version: 2.9.0` element to prevent that PVC creation.
