### PR TITLE
bundle.yaml: renames istio-ingressgateway -> istio-gateway in relation

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -9,4 +9,4 @@ applications:
     source: ./charms/istio-pilot
     scale: 1
 relations:
-  - [istio-ingressgateway:istio-pilot, istio-pilot:istio-pilot]
+  - [istio-gateway:istio-pilot, istio-pilot:istio-pilot]


### PR DESCRIPTION
The was renamed `istio-ingressgateway`  -> `istio-gateway` recently, this change should also be reflected in the relation.