### PR TITLE
Pin markupsafe==2.0.1 for Jinja bug workaround

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -27,7 +27,7 @@ jobs:
 
     - uses: balchua/microk8s-actions@v0.2.2
       with:
-        channel: 'latest/stable'
+        channel: '1.21/stable'
         addons: '["dns", "storage", "rbac", "metallb:10.64.140.43-10.64.140.49"]'
 
     - name: Install dependencies

--- a/charms/istio-pilot/requirements.txt
+++ b/charms/istio-pilot/requirements.txt
@@ -1,4 +1,5 @@
 ops==1.3.0
 oci-image==1.0.0
+markupsafe==2.0.1
 jinja2==2.11.3
 serialized-data-interface<0.4


### PR DESCRIPTION
Pin Jinja dependency markupsafe to v2.0.1

This issue is caused by a change in Jinja's dependencies.  This is a workaround that forces an older version of markupsafe for the time being.

https://github.com/pallets/jinja/issues/1585