### PR TITLE
istio-gateway/src/charm.py: replaces on.install with on.start event

### DIFF
--- a/charms/istio-gateway/src/charm.py
+++ b/charms/istio-gateway/src/charm.py
@@ -36,13 +36,13 @@ class Operator(CharmBase):
         # Every lightkube API call will use the model name as the namespace by default
         self.lightkube_client = Client(namespace=self.model.name, field_manager="lightkube")
 
-        self.framework.observe(self.on.install, self.install)
-        self.framework.observe(self.on["istio-pilot"].relation_changed, self.install)
-        self.framework.observe(self.on.config_changed, self.install)
+        self.framework.observe(self.on.start, self.start)
+        self.framework.observe(self.on["istio-pilot"].relation_changed, self.start)
+        self.framework.observe(self.on.config_changed, self.start)
         self.framework.observe(self.on.remove, self.remove)
 
-    def install(self, event):
-        """Install charm."""
+    def start(self, event):
+        """Event handler for StartEevnt."""
 
         if self.model.config['kind'] not in ('ingress', 'egress'):
             self.model.unit.status = BlockedStatus('Config item `kind` must be set')


### PR DESCRIPTION
Checking certain conditions, like the existance of a relation, should be done on StartEvent instead of on InstallEvent, as we can allow the charm to setup and other events to happen, such as relation-created.
We can ensure that if any check we have in this event handler is failing, it is due to an omission and not because we didn't allow the charm to actually meet those conditions.