### PR TITLE
Improves bundle testing and removes oci-image resource

### DIFF
--- a/charms/istio-gateway/metadata.yaml
+++ b/charms/istio-gateway/metadata.yaml
@@ -4,17 +4,6 @@ summary: |
 description: |
   https://istio.io/latest/docs/tasks/traffic-management/ingress/
   https://istio.io/latest/docs/tasks/traffic-management/egress/
-
-containers:
-  noop:
-    resource: noop
-
-resources:
-  noop:
-    type: oci-image
-    description: ''
-    upstream-source: alpine:latest
-
 requires:
   istio-pilot:
     interface: k8s-service

--- a/charms/istio-gateway/tests/unit/conftest.py
+++ b/charms/istio-gateway/tests/unit/conftest.py
@@ -4,20 +4,6 @@ from charm import Operator
 from ops.testing import Harness
 
 
-class Helpers:
-    @staticmethod
-    def begin_noop(harness):
-        # Most of the tests use these lines to kick things off
-        harness.begin_with_initial_hooks()
-        container = harness.model.unit.get_container('noop')
-        harness.charm.on['noop'].pebble_ready.emit(container)
-
-
-@pytest.fixture(scope="session")
-def helpers():
-    return Helpers()
-
-
 @pytest.fixture
 def harness():
     return Harness(Operator)
@@ -38,18 +24,10 @@ def kind(request):
 
 
 @pytest.fixture()
-def configured_harness(harness, kind, helpers):
+def configured_harness(harness, kind):
     harness.set_leader(True)
 
     harness.update_config({'kind': kind})
-    harness.add_oci_resource(
-        "noop",
-        {
-            "registrypath": "",
-            "username": "",
-            "password": "",
-        },
-    )
     rel_id = harness.add_relation("istio-pilot", "app")
 
     harness.add_relation_unit(rel_id, "app/0")
@@ -60,6 +38,6 @@ def configured_harness(harness, kind, helpers):
         {"_supported_versions": "- v1", "data": yaml.dump(data)},
     )
 
-    helpers.begin_noop(harness)
+    harness.begin_with_initial_hooks()
 
     return harness

--- a/charms/istio-gateway/tests/unit/test_charm.py
+++ b/charms/istio-gateway/tests/unit/test_charm.py
@@ -41,15 +41,15 @@ def test_install_no_kind(harness):
     assert harness.charm.model.unit.status == BlockedStatus('Config item `kind` must be set')
 
 
-def test_install_no_rel(harness, helpers):
+def test_install_no_rel(harness):
     harness.set_leader(True)
     harness.update_config({'kind': 'ingress'})
-    helpers.begin_noop(harness)
+    harness.begin_with_initial_hooks()
 
     assert harness.charm.model.unit.status == BlockedStatus('Waiting for istio-pilot relation')
 
 
-def test_start_apply(configured_harness, kind, mocked_client, helpers):
+def test_start_apply(configured_harness, kind, mocked_client):
     # Reset the mock so that the calls list does not include any calls from other hooks
     mocked_client.reset_mock()
 

--- a/charms/istio-pilot/metadata.yaml
+++ b/charms/istio-pilot/metadata.yaml
@@ -4,17 +4,6 @@ summary: |
   Istio Service Mesh.
 description: |
   https://istio.io/latest/docs/reference/commands/pilot-discovery/
-
-containers:
-  noop:
-    resource: noop
-
-resources:
-  noop:
-    type: oci-image
-    description: ''
-    upstream-source: alpine:latest
-
 provides:
   istio-pilot:
     interface: k8s-service

--- a/charms/istio-pilot/tests/unit/test_charm.py
+++ b/charms/istio-pilot/tests/unit/test_charm.py
@@ -9,8 +9,6 @@ from lightkube.core.exceptions import ApiError
 def test_events(harness, mocker):
     harness.set_leader(True)
     harness.begin_with_initial_hooks()
-    container = harness.model.unit.get_container('noop')
-    harness.charm.on['noop'].pebble_ready.emit(container)
 
     install = mocker.patch('charm.Operator.install')
     remove = mocker.patch('charm.Operator.remove')
@@ -73,8 +71,6 @@ def test_basic(harness, subprocess, mocker):
     check_call = subprocess.check_call
     harness.set_leader(True)
     harness.begin_with_initial_hooks()
-    container = harness.model.unit.get_container('noop')
-    harness.charm.on['noop'].pebble_ready.emit(container)
 
     expected_args = [
         './istioctl',
@@ -97,14 +93,7 @@ def test_with_ingress_relation(harness, subprocess, mocked_client, helpers, mock
     check_call = subprocess.check_call
 
     harness.set_leader(True)
-    harness.add_oci_resource(
-        "noop",
-        {
-            "registrypath": "",
-            "username": "",
-            "password": "",
-        },
-    )
+
     rel_id = harness.add_relation("ingress", "app")
     harness.add_relation_unit(rel_id, "app/0")
     data = {"service": "service-name", "port": 6666, "prefix": "/"}
@@ -188,14 +177,6 @@ def test_with_ingress_auth_relation(harness, subprocess, helpers, mocked_client,
     check_call = subprocess.check_call
 
     harness.set_leader(True)
-    harness.add_oci_resource(
-        "noop",
-        {
-            "registrypath": "",
-            "username": "",
-            "password": "",
-        },
-    )
     rel_id = harness.add_relation("ingress-auth", "app")
 
     harness.add_relation_unit(rel_id, "app/0")
@@ -317,14 +298,6 @@ def test_removal(harness, subprocess, mocked_client, helpers, mocker):
     )
 
     harness.set_leader(True)
-    harness.add_oci_resource(
-        "noop",
-        {
-            "registrypath": "",
-            "username": "",
-            "password": "",
-        },
-    )
 
     harness.begin_with_initial_hooks()
 


### PR DESCRIPTION
This PR introduces the following:
* charms/*/metadata.yaml: replaces oci-image with noop
* tests/test_bundle.py: replaces build_bundle with explicit & individual methods
    juju-bundle is not as transparent as using individual commands, and since this is a test, we can afford the extra steps, so we can be more explicit on what we are executing and what part is causing issues in case of a failure.

Depends on #63 