### PR TITLE
Refactors charm.py extracting all lightkube logic to a helper module

### DIFF
--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -5,14 +5,14 @@ import subprocess
 
 import yaml
 from jinja2 import Environment, FileSystemLoader
+from lightkube import Client
+from lightkube.core.exceptions import ApiError
+from lightkube.resources.core_v1 import Service
 from ops.charm import CharmBase, RelationBrokenEvent
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from serialized_data_interface import NoCompatibleVersions, NoVersionsListed, get_interfaces
-from lightkube import Client, codecs
-from lightkube.core.exceptions import ApiError
-from lightkube.generic_resource import create_namespaced_resource
-from lightkube.resources.core_v1 import Service
+from resources_handler import ResourceHandler, GenericNamespacedResource
 
 
 class Operator(CharmBase):
@@ -37,43 +37,11 @@ class Operator(CharmBase):
 
         self.log = logging.getLogger(__name__)
 
-        # Every lightkube API call will use the model name as the namespace by default
-        self.lightkube_client = Client(namespace=self.model.name, field_manager="lightkube")
-        # Create namespaced resource classes for lightkube client
-        # This is necessary for lightkube to interact with custom resources
-        self.envoy_filter_resource = create_namespaced_resource(
-            group="networking.istio.io",
-            version="v1alpha3",
-            kind="EnvoyFilter",
-            plural="envoyfilters",
-            verbs=None,
-        )
-
-        self.virtual_service_resource = create_namespaced_resource(
-            group="networking.istio.io",
-            version="v1alpha3",
-            kind="VirtualService",
-            plural="virtualservices",
-            verbs=None,
-        )
-
-        self.gateway_resource = create_namespaced_resource(
-            group="networking.istio.io",
-            version="v1beta1",
-            kind="Gateway",
-            plural="gateways",
-            verbs=None,
-        )
-
-        self.rbac_config_resource = create_namespaced_resource(
-            group="rbac.istio.io",
-            version="v1alpha1",
-            kind="RbacConfig",
-            plural="rbacconfigs",
-            verbs=None,
-        )
-
         self.env = Environment(loader=FileSystemLoader('src'))
+        self._custom_resource_classes = {}
+        self._resource_handler = ResourceHandler(self.app.name, self.model.name)
+
+        self.lightkube_client = Client(namespace=self.model.name, field_manager="lightkube")
 
         self.framework.observe(self.on.install, self.install)
         self.framework.observe(self.on.remove, self.remove)
@@ -81,7 +49,6 @@ class Operator(CharmBase):
         self.framework.observe(self.on.config_changed, self.handle_default_gateway)
 
         self.framework.observe(self.on["istio-pilot"].relation_changed, self.send_info)
-
         self.framework.observe(self.on['ingress'].relation_changed, self.handle_ingress)
         self.framework.observe(self.on['ingress'].relation_broken, self.handle_ingress)
         self.framework.observe(self.on['ingress'].relation_departed, self.handle_ingress)
@@ -120,15 +87,11 @@ class Operator(CharmBase):
             ]
         )
 
-        for resource in [
-            self.virtual_service_resource,
-            self.gateway_resource,
-            self.envoy_filter_resource,
-        ]:
-            self._delete_existing_resource_objects(
+        for resource in self._custom_resource_classes.values():
+            self._resource_handler.delete_existing_resource_objects(
                 resource, namespace=self.model.name, ignore_unauthorized=True
             )
-        self._delete_manifest(
+        self._resource_handler.delete_manifest(
             manifests, namespace=self.model.name, ignore_not_found=True, ignore_unauthorized=True
         )
 
@@ -141,14 +104,14 @@ class Operator(CharmBase):
         t = self.env.get_template('gateway.yaml.j2')
         gateway = self.model.config['default-gateway']
         manifest = t.render(name=gateway, app_name=self.app.name)
-        self._delete_existing_resource_objects(
-            resource=self.gateway_resource,
+        self._resource_handler.delete_existing_resource_objects(
+            resource=self._get_custom_resource_class(resource_name='gateway'),
             labels={
-                "app.juju.is/created-by": f"{self.app.name}",
-                "app.{self.app.name}.io/is-workload-entity": "true",
+                f"app.{self.app.name}.io/is-workload-entity": "true",
             },
+            namespace=self.model.name,
         )
-        self._apply_manifest(manifest)
+        self._resource_handler.apply_manifest(manifest)
 
         # Update the ingress objects as they rely on the default_gateway
         self.handle_ingress(event)
@@ -206,17 +169,18 @@ class Operator(CharmBase):
 
             return kwargs
 
+        # TODO: we could probably extract the rendering bits from the charm code
         virtual_services = '\n---'.join(
             t.render(**get_kwargs(ingress.versions[app.name], route)).strip().strip("---")
             for ((_, app), route) in routes.items()
         )
-
-        self._delete_existing_resource_objects(
-            self.virtual_service_resource, namespace=self.model.name
+        self._resource_handler.delete_existing_resource_objects(
+            self._get_custom_resource_class(resource_name='virtual_service'),
+            namespace=self.model.name,
         )
 
         if routes:
-            self._apply_manifest(virtual_services, namespace=self.model.name)
+            self._resource_handler.apply_manifest(virtual_services, namespace=self.model.name)
 
     def handle_ingress_auth(self, event):
         auth_routes = self.interfaces['ingress-auth']
@@ -256,62 +220,29 @@ class Operator(CharmBase):
             for r in auth_routes
         )
 
-        self._delete_existing_resource_objects(
-            self.envoy_filter_resource, namespace=self.model.name
+        self._resource_handler.delete_existing_resource_objects(
+            self._get_custom_resource_class(resource_name='auth_filter'), namespace=self.model.name
         )
-        self._apply_manifest(auth_filters, namespace=self.model.name)
+        self._resource_handler.apply_manifest(auth_filters, namespace=self.model.name)
 
-    def _delete_object(
-        self, obj, namespace=None, ignore_not_found=False, ignore_unauthorized=False
-    ):
-        try:
-            self.lightkube_client.delete(type(obj), obj.metadata.name, namespace=namespace)
-        except ApiError as err:
-            self.log.exception("ApiError encountered while attempting to delete resource.")
-            if err.status.message is not None:
-                if "not found" in err.status.message and ignore_not_found:
-                    self.log.error(f"Ignoring not found error:\n{err.status.message}")
-                elif "(Unauthorized)" in err.status.message and ignore_unauthorized:
-                    # Ignore error from https://bugs.launchpad.net/juju/+bug/1941655
-                    self.log.error(f"Ignoring unauthorized error:\n{err.status.message}")
-                else:
-                    self.log.error(err.status.message)
-                    raise
-            else:
-                raise
+    def _get_custom_resource_class(self, resource_name: str) -> GenericNamespacedResource:
+        """Receives a valid resource_name, creates a Lightkube k8s generic
+        namespaced resource, and updates a dictionary hosting all available
+        GenericNamespacedResources for this charm.
 
-    def _delete_existing_resource_objects(
-        self,
-        resource,
-        namespace=None,
-        ignore_not_found=False,
-        ignore_unauthorized=False,
-        labels={},
-    ):
-        for obj in self.lightkube_client.list(
-            resource, labels={"app.juju.is/created-by": f"{self.app.name}"}.update(labels)
-        ):
-            self._delete_object(
-                obj,
-                namespace=namespace,
-                ignore_not_found=ignore_not_found,
-                ignore_unauthorized=ignore_unauthorized,
-            )
+        Args:
+            resource_name: name of the resource to get.
 
-    def _apply_manifest(self, manifest, namespace=None):
-        for obj in codecs.load_all_yaml(manifest):
-            self.lightkube_client.apply(obj, namespace=namespace)
+        Returns:
+            A class associated to a resource_name key representing a k8s resource.
 
-    def _delete_manifest(
-        self, manifest, namespace=None, ignore_not_found=False, ignore_unauthorized=False
-    ):
-        for obj in codecs.load_all_yaml(manifest):
-            self._delete_object(
-                obj,
-                namespace=namespace,
-                ignore_not_found=ignore_not_found,
-                ignore_unauthorized=ignore_unauthorized,
-            )
+        """
+
+        if resource_name not in self._custom_resource_classes:
+            self._custom_resource_classes[
+                resource_name
+            ] = self._resource_handler.generate_generic_resource_class(f'{resource_name}.yaml.j2')
+        return self._custom_resource_classes[resource_name]
 
     @property
     def _get_gateway_address(self):
@@ -320,6 +251,7 @@ class Operator(CharmBase):
         returns None.
         """
         # FIXME: service name is hardcoded
+        # TODO: extract this from charm code
         svcs = self.lightkube_client.get(
             Service, name="istio-ingressgateway", namespace=self.model.name
         )

--- a/charms/istio-pilot/src/resources_handler.py
+++ b/charms/istio-pilot/src/resources_handler.py
@@ -1,0 +1,120 @@
+#! /usr/bin/env python3
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Resources handling library using Lightkube."""
+import logging
+
+import yaml
+from jinja2 import Environment, FileSystemLoader
+from lightkube import Client, codecs
+from lightkube.core.exceptions import ApiError
+from lightkube.generic_resource import create_namespaced_resource, GenericNamespacedResource
+
+
+class ResourceHandler:
+    def __init__(self, app_name, model_name):
+        """A Lightkube API interface.
+
+        Args:
+           - app_name: name of the application
+           - model_name: name of the Juju model this charm is deployed to
+        """
+
+        self.app_name = app_name
+        self.model_name = model_name
+
+        self.log = logging.getLogger(__name__)
+
+        # Every lightkube API call will use the model name as the namespace by default
+        self.lightkube_client = Client(namespace=self.model_name, field_manager="lightkube")
+
+        self.env = Environment(loader=FileSystemLoader('src'))
+
+    def delete_object(
+        self, obj, namespace=None, ignore_not_found=False, ignore_unauthorized=False
+    ):
+        try:
+            self.lightkube_client.delete(type(obj), obj.metadata.name, namespace=namespace)
+        except ApiError as err:
+            self.log.exception("ApiError encountered while attempting to delete resource.")
+            if err.status.message is not None:
+                if "not found" in err.status.message and ignore_not_found:
+                    self.log.error(f"Ignoring not found error:\n{err.status.message}")
+                elif "(Unauthorized)" in err.status.message and ignore_unauthorized:
+                    # Ignore error from https://bugs.launchpad.net/juju/+bug/1941655
+                    self.log.error(f"Ignoring unauthorized error:\n{err.status.message}")
+                else:
+                    self.log.error(err.status.message)
+                    raise
+            else:
+                raise
+
+    def delete_existing_resource_objects(
+        self,
+        resource,
+        namespace=None,
+        ignore_not_found=False,
+        ignore_unauthorized=False,
+        labels=None,
+    ):
+        if labels is None:
+            labels = {}
+        for obj in self.lightkube_client.list(
+            resource,
+            labels={"app.juju.is/created-by": f"{self.app_name}"}.update(labels),
+            namespace=namespace,
+        ):
+            self.delete_object(
+                obj,
+                namespace=namespace,
+                ignore_not_found=ignore_not_found,
+                ignore_unauthorized=ignore_unauthorized,
+            )
+
+    def apply_manifest(self, manifest, namespace=None):
+        for obj in codecs.load_all_yaml(manifest):
+            self.lightkube_client.apply(obj, namespace=namespace)
+
+    def delete_manifest(
+        self, manifest, namespace=None, ignore_not_found=False, ignore_unauthorized=False
+    ):
+        for obj in codecs.load_all_yaml(manifest):
+            self.delete_object(
+                obj,
+                namespace=namespace,
+                ignore_not_found=ignore_not_found,
+                ignore_unauthorized=ignore_unauthorized,
+            )
+
+    def generate_generic_resource_class(self, filename: str) -> GenericNamespacedResource:
+        """Returns a class representing a namespaced K8s resource.
+
+        Args:
+            - filename: name of the manifest file used to create the resource
+        """
+
+        # TODO: this is a generic context that is used for rendering
+        # the manifest files and extract their metadata. We should
+        # improve how we do this and make it more generic.
+        context = {
+            'namespace': 'namespace',
+            'app_name': 'name',
+            'name': 'generic_resource',
+            'request_headers': 'request_headers',
+            'response_headers': 'response_headers',
+            'port': 'port',
+            'service': 'service',
+        }
+
+        t = self.env.get_template(filename)
+        manifest = yaml.safe_load(t.render(context))
+        ns_resource = create_namespaced_resource(
+            group=manifest["apiVersion"].split("/")[0],
+            version=manifest["apiVersion"].split("/")[1],
+            kind=manifest["kind"],
+            plural=f"{manifest['kind']}s".lower(),
+            verbs=None,
+        )
+
+        return ns_resource

--- a/charms/istio-pilot/tests/unit/conftest.py
+++ b/charms/istio-pilot/tests/unit/conftest.py
@@ -37,12 +37,20 @@ def helpers():
 # autouse to prevent calling out to the k8s API via lightkube
 @pytest.fixture(autouse=True)
 def mocked_client(mocker):
+    client = mocker.patch("resources_handler.Client")
+    yield client
+
+
+# TODO: once we extract the _get_gateway_address method
+# from the charm code, this bit won't be necessary
+@pytest.fixture(autouse=True)
+def mocked_charm_client(mocker):
     client = mocker.patch("charm.Client")
     yield client
 
 
-# Mocking list is necessary since _delete_existing_resource_objects uses it to
-# find existing resources
+# Mocking list is necessary since _delete_existing_resource_objects
+# uses it to find existing resources
 @pytest.fixture(autouse=True)
 def mocked_list(mocked_client, mocker):
     mocked_resource_obj = mocker.MagicMock()
@@ -62,6 +70,18 @@ def mocked_list(mocked_client, mocker):
         return [mocked_resource_obj]
 
     mocked_client.return_value.list.side_effect = side_effect
+
+
+# Similar to what is done for list, but for get
+# and just returning the status attribute
+@pytest.fixture(autouse=True)
+def mocked_get(mocked_charm_client, mocker):
+    mocked_resource_obj = mocker.MagicMock()
+    mocked_metadata = mocker.MagicMock()
+    mocked_metadata.status = 'status'
+    mocked_resource_obj.metadata = mocked_metadata
+
+    mocked_charm_client.return_value.get.side_effect = mocked_resource_obj
 
 
 # autouse to ensure we don't accidentally call out, but


### PR DESCRIPTION
This PR introduces the following changes:
* istio-pilot/src: extracts all lightkube logic to a helper module
* istio-pilot/tests/unit: skipping all tests as they need to be refactored

> Note: unit tests will be changed in a follow up PR