### PR TITLE
fix: naming of istio-ingressgateway service

### DIFF
--- a/charms/istio-gateway/src/charm.py
+++ b/charms/istio-gateway/src/charm.py
@@ -68,6 +68,7 @@ class Operator(CharmBase):
         )
 
         for obj in codecs.load_all_yaml(rendered):
+            self.log.debug(f"Deploying {obj.metadata.name} of kind {obj.kind}")
             self.lightkube_client.apply(obj, namespace=obj.metadata.namespace)
 
         self.unit.status = ActiveStatus()

--- a/charms/istio-gateway/src/manifest.yaml
+++ b/charms/istio-gateway/src/manifest.yaml
@@ -9,7 +9,7 @@ metadata:
     istio.io/rev: default
     operator.istio.io/component: "{{ kind|capitalize }}Gateways"
     release: istio
-  name: istio-{{ kind }}gateway-service-account
+  name: istio-{{ kind }}gateway-workload-service-account
   namespace: {{ namespace }}
 ---
 apiVersion: apps/v1
@@ -22,7 +22,7 @@ metadata:
     istio.io/rev: default
     operator.istio.io/component: {{ kind|capitalize }}Gateways
     release: istio
-  name: istio-{{ kind }}gateway
+  name: istio-{{ kind }}gateway-workload
   namespace: {{ namespace }}
 spec:
   selector:
@@ -49,7 +49,7 @@ spec:
         istio.io/rev: default
         operator.istio.io/component: {{ kind|capitalize }}Gateways
         release: istio
-        service.istio.io/canonical-name: istio-{{ kind }}gateway
+        service.istio.io/canonical-name: istio-{{ kind }}gateway-workload
         service.istio.io/canonical-revision: latest
         sidecar.istio.io/inject: "false"
     spec:
@@ -132,9 +132,9 @@ spec:
                 fieldRef:
                   fieldPath: spec.serviceAccountName
             - name: ISTIO_META_WORKLOAD_NAME
-              value: istio-{{ kind }}gateway
+              value: istio-{{ kind }}gateway-workload
             - name: ISTIO_META_OWNER
-              value: kubernetes://apis/apps/v1/namespaces/{{ namespace }}/deployments/istio-{{ kind }}gateway
+              value: kubernetes://apis/apps/v1/namespaces/{{ namespace }}/deployments/istio-{{ kind }}gateway-workload
             - name: ISTIO_META_MESH_ID
               value: cluster.local
             - name: TRUST_DOMAIN
@@ -204,7 +204,7 @@ spec:
         runAsGroup: 1337
         runAsNonRoot: true
         runAsUser: 1337
-      serviceAccountName: istio-{{ kind }}gateway-service-account
+      serviceAccountName: istio-{{ kind }}gateway-workload-service-account
       volumes:
         - configMap:
             name: istio-ca-root-cert
@@ -236,11 +236,11 @@ spec:
         - name: {{ kind }}gateway-certs
           secret:
             optional: true
-            secretName: istio-{{ kind }}gateway-certs
+            secretName: istio-{{ kind }}gateway-workload-certs
         - name: {{ kind }}gateway-ca-certs
           secret:
             optional: true
-            secretName: istio-{{ kind }}gateway-ca-certs
+            secretName: istio-{{ kind }}gateway-workload-ca-certs
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
@@ -252,7 +252,7 @@ metadata:
     istio.io/rev: default
     operator.istio.io/component: "{{ kind|capitalize }}Gateways"
     release: istio
-  name: istio-{{ kind }}gateway
+  name: istio-{{ kind }}gateway-workload
   namespace: {{ namespace }}
 spec:
   minAvailable: 1
@@ -269,7 +269,7 @@ metadata:
     istio.io/rev: default
     operator.istio.io/component: "{{ kind|capitalize }}Gateways"
     release: istio
-  name: istio-{{ kind }}gateway-sds
+  name: istio-{{ kind }}gateway-workload-sds
   namespace: {{ namespace }}
 rules:
   - apiGroups: [""]
@@ -284,15 +284,15 @@ metadata:
     istio.io/rev: default
     operator.istio.io/component: "{{ kind|capitalize }}Gateways"
     release: istio
-  name: istio-{{ kind }}gateway-sds
+  name: istio-{{ kind }}gateway-workload-sds
   namespace: {{ namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: istio-{{ kind }}gateway-sds
+  name: istio-{{ kind }}gateway-workload-sds
 subjects:
   - kind: ServiceAccount
-    name: istio-{{ kind }}gateway-service-account
+    name: istio-{{ kind }}gateway-workload-service-account
 ---
 apiVersion: v1
 kind: Service
@@ -304,7 +304,7 @@ metadata:
     istio.io/rev: default
     operator.istio.io/component: "{{ kind|capitalize }}Gateways"
     release: istio
-  name: istio-{{ kind }}gateway
+  name: istio-{{ kind }}gateway-workload
   namespace: {{ namespace }}
 spec:
   ports:

--- a/charms/istio-gateway/tests/unit/data/egress-example.yaml
+++ b/charms/istio-gateway/tests/unit/data/egress-example.yaml
@@ -8,7 +8,7 @@ metadata:
     istio.io/rev: default
     operator.istio.io/component: "EgressGateways"
     release: istio
-  name: istio-egressgateway-service-account
+  name: istio-egressgateway-workload-service-account
   namespace: None
 ---
 apiVersion: apps/v1
@@ -21,7 +21,7 @@ metadata:
     istio.io/rev: default
     operator.istio.io/component: EgressGateways
     release: istio
-  name: istio-egressgateway
+  name: istio-egressgateway-workload
   namespace: None
 spec:
   selector:
@@ -48,7 +48,7 @@ spec:
         istio.io/rev: default
         operator.istio.io/component: EgressGateways
         release: istio
-        service.istio.io/canonical-name: istio-egressgateway
+        service.istio.io/canonical-name: istio-egressgateway-workload
         service.istio.io/canonical-revision: latest
         sidecar.istio.io/inject: "false"
     spec:
@@ -133,9 +133,9 @@ spec:
                 fieldRef:
                   fieldPath: spec.serviceAccountName
             - name: ISTIO_META_WORKLOAD_NAME
-              value: istio-egressgateway
+              value: istio-egressgateway-workload
             - name: ISTIO_META_OWNER
-              value: kubernetes://apis/apps/v1/namespaces/None/deployments/istio-egressgateway
+              value: kubernetes://apis/apps/v1/namespaces/None/deployments/istio-egressgateway-workload
             - name: ISTIO_META_MESH_ID
               value: cluster.local
             - name: TRUST_DOMAIN
@@ -205,7 +205,7 @@ spec:
         runAsGroup: 1337
         runAsNonRoot: true
         runAsUser: 1337
-      serviceAccountName: istio-egressgateway-service-account
+      serviceAccountName: istio-egressgateway-workload-service-account
       volumes:
         - configMap:
             name: istio-ca-root-cert
@@ -237,11 +237,11 @@ spec:
         - name: egressgateway-certs
           secret:
             optional: true
-            secretName: istio-egressgateway-certs
+            secretName: istio-egressgateway-workload-certs
         - name: egressgateway-ca-certs
           secret:
             optional: true
-            secretName: istio-egressgateway-ca-certs
+            secretName: istio-egressgateway-workload-ca-certs
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
@@ -253,7 +253,7 @@ metadata:
     istio.io/rev: default
     operator.istio.io/component: "EgressGateways"
     release: istio
-  name: istio-egressgateway
+  name: istio-egressgateway-workload
   namespace: None
 spec:
   minAvailable: 1
@@ -270,7 +270,7 @@ metadata:
     istio.io/rev: default
     operator.istio.io/component: "EgressGateways"
     release: istio
-  name: istio-egressgateway-sds
+  name: istio-egressgateway-workload-sds
   namespace: None
 rules:
   - apiGroups: [""]
@@ -285,15 +285,15 @@ metadata:
     istio.io/rev: default
     operator.istio.io/component: "EgressGateways"
     release: istio
-  name: istio-egressgateway-sds
+  name: istio-egressgateway-workload-sds
   namespace: None
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: istio-egressgateway-sds
+  name: istio-egressgateway-workload-sds
 subjects:
   - kind: ServiceAccount
-    name: istio-egressgateway-service-account
+    name: istio-egressgateway-workload-service-account
 ---
 apiVersion: v1
 kind: Service
@@ -305,7 +305,7 @@ metadata:
     istio.io/rev: default
     operator.istio.io/component: "EgressGateways"
     release: istio
-  name: istio-egressgateway
+  name: istio-egressgateway-workload
   namespace: None
 spec:
   ports:

--- a/charms/istio-gateway/tests/unit/data/ingress-example.yaml
+++ b/charms/istio-gateway/tests/unit/data/ingress-example.yaml
@@ -8,7 +8,7 @@ metadata:
     istio.io/rev: default
     operator.istio.io/component: "IngressGateways"
     release: istio
-  name: istio-ingressgateway-service-account
+  name: istio-ingressgateway-workload-service-account
   namespace: None
 ---
 apiVersion: apps/v1
@@ -21,7 +21,7 @@ metadata:
     istio.io/rev: default
     operator.istio.io/component: IngressGateways
     release: istio
-  name: istio-ingressgateway
+  name: istio-ingressgateway-workload
   namespace: None
 spec:
   selector:
@@ -48,7 +48,7 @@ spec:
         istio.io/rev: default
         operator.istio.io/component: IngressGateways
         release: istio
-        service.istio.io/canonical-name: istio-ingressgateway
+        service.istio.io/canonical-name: istio-ingressgateway-workload
         service.istio.io/canonical-revision: latest
         sidecar.istio.io/inject: "false"
     spec:
@@ -133,9 +133,9 @@ spec:
                 fieldRef:
                   fieldPath: spec.serviceAccountName
             - name: ISTIO_META_WORKLOAD_NAME
-              value: istio-ingressgateway
+              value: istio-ingressgateway-workload
             - name: ISTIO_META_OWNER
-              value: kubernetes://apis/apps/v1/namespaces/None/deployments/istio-ingressgateway
+              value: kubernetes://apis/apps/v1/namespaces/None/deployments/istio-ingressgateway-workload
             - name: ISTIO_META_MESH_ID
               value: cluster.local
             - name: TRUST_DOMAIN
@@ -205,7 +205,7 @@ spec:
         runAsGroup: 1337
         runAsNonRoot: true
         runAsUser: 1337
-      serviceAccountName: istio-ingressgateway-service-account
+      serviceAccountName: istio-ingressgateway-workload-service-account
       volumes:
         - configMap:
             name: istio-ca-root-cert
@@ -237,11 +237,11 @@ spec:
         - name: ingressgateway-certs
           secret:
             optional: true
-            secretName: istio-ingressgateway-certs
+            secretName: istio-ingressgateway-workload-certs
         - name: ingressgateway-ca-certs
           secret:
             optional: true
-            secretName: istio-ingressgateway-ca-certs
+            secretName: istio-ingressgateway-workload-ca-certs
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
@@ -253,7 +253,7 @@ metadata:
     istio.io/rev: default
     operator.istio.io/component: "IngressGateways"
     release: istio
-  name: istio-ingressgateway
+  name: istio-ingressgateway-workload
   namespace: None
 spec:
   minAvailable: 1
@@ -270,7 +270,7 @@ metadata:
     istio.io/rev: default
     operator.istio.io/component: "IngressGateways"
     release: istio
-  name: istio-ingressgateway-sds
+  name: istio-ingressgateway-workload-sds
   namespace: None
 rules:
   - apiGroups: [""]
@@ -285,15 +285,15 @@ metadata:
     istio.io/rev: default
     operator.istio.io/component: "IngressGateways"
     release: istio
-  name: istio-ingressgateway-sds
+  name: istio-ingressgateway-workload-sds
   namespace: None
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: istio-ingressgateway-sds
+  name: istio-ingressgateway-workload-sds
 subjects:
   - kind: ServiceAccount
-    name: istio-ingressgateway-service-account
+    name: istio-ingressgateway-workload-service-account
 ---
 apiVersion: v1
 kind: Service
@@ -305,7 +305,7 @@ metadata:
     istio.io/rev: default
     operator.istio.io/component: "IngressGateways"
     release: istio
-  name: istio-ingressgateway
+  name: istio-ingressgateway-workload
   namespace: None
 spec:
   ports:

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -111,7 +111,7 @@ async def test_deploy_bookinfo_example(ops_test: OpsTest):
     gateway_json = await ops_test.run(
         'kubectl',
         'get',
-        'services/istio-ingressgateway',
+        'services/istio-ingressgateway-workload',
         '-n',
         ops_test.model_name,
         '-ojson',


### PR DESCRIPTION
If istio-gateway was deployed as kind=ingress with application name istio-ingressgateway, a service in manifest.yaml had a name collision with the juju-created istio-ingressgateway service.  This is fixed by adding suffixes on the resource names.

All credits to @ca-scribner 