### PR TITLE
istio-pilot: extracts get_gateway_adress method from charm code

### DIFF
--- a/charms/istio-pilot/src/resources_handler.py
+++ b/charms/istio-pilot/src/resources_handler.py
@@ -13,6 +13,7 @@ from lightkube import Client, codecs
 from lightkube.core.exceptions import ApiError
 from lightkube.generic_resource import create_namespaced_resource, GenericNamespacedResource
 from lightkube.core.resource import Resource
+from lightkube.resources.core_v1 import Service
 
 
 class ResourceHandler:
@@ -150,6 +151,17 @@ class ResourceHandler:
             for obj in diff_obj:
                 self.delete_object(obj)
             self.apply_manifest(desired_resources, namespace=namespace)
+
+    def get_gateway_address(self):
+        """Look up the load balancer address for the ingress gateway.
+        If the gateway isn't available or doesn't have a load balancer address yet,
+        returns None.
+        """
+        # FIXME: service name is hardcoded
+        svcs = self.lightkube_client.get(
+            Service, name="istio-ingressgateway", namespace=self.model_name
+        )
+        return svcs.status.loadBalancer.ingress[0].ip
 
 
 def in_left_not_right(left, right):

--- a/charms/istio-pilot/tests/unit/conftest.py
+++ b/charms/istio-pilot/tests/unit/conftest.py
@@ -41,24 +41,16 @@ def mocked_client(mocker):
     yield client
 
 
-# TODO: once we extract the _get_gateway_address method
-# from the charm code, this bit won't be necessary
-@pytest.fixture(autouse=True)
-def mocked_charm_client(mocker):
-    client = mocker.patch("charm.Client")
-    yield client
-
-
 # Similar to what is done for list, but for get
 # and just returning the status attribute
 @pytest.fixture(autouse=True)
-def mocked_get(mocked_charm_client, mocker):
+def mocked_get(mocked_client, mocker):
     mocked_resource_obj = mocker.MagicMock()
     mocked_metadata = mocker.MagicMock()
     mocked_metadata.status = 'status'
     mocked_resource_obj.metadata = mocked_metadata
 
-    mocked_charm_client.return_value.get.side_effect = mocked_resource_obj
+    mocked_client.return_value.get.side_effect = mocked_resource_obj
 
 
 # autouse to ensure we don't accidentally call out, but

--- a/charms/istio-pilot/tests/unit/test_charm.py
+++ b/charms/istio-pilot/tests/unit/test_charm.py
@@ -19,12 +19,9 @@ def mocked_list(mocked_client, mocker):
         # 'unittest.mock.MagicMock does not seem possible. So when checking that the correct
         # resources are being deleted we will check the name of the object being deleted and just
         # use the the class name for obj.metadata.name
-        resource_obj = args[0]
-        print(resource_obj.metadata.__str__)
         mocked_metadata = mocker.MagicMock()
         mocked_metadata.name = str(args[0].__name__)
         mocked_resource_obj.metadata = mocked_metadata
-        mocked_resource_obj.kind = str(args[0].__name__)
         return [mocked_resource_obj]
 
     mocked_client.return_value.list.side_effect = side_effect


### PR DESCRIPTION
This is the last change in a series of changes that removed
lightkube calls from the charm code. This commit takes out
_get_gateway_adress() from charm.py and places it
in resources_handler.py