### PR TITLE
Replaces "object" with "resource" to keep standard

### DIFF
--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -88,7 +88,7 @@ class Operator(CharmBase):
         )
 
         for resource in self._custom_resource_classes.values():
-            self._resource_handler.delete_existing_resource_objects(
+            self._resource_handler.delete_existing_resources(
                 resource, namespace=self.model.name, ignore_unauthorized=True
             )
         self._resource_handler.delete_manifest(
@@ -99,12 +99,12 @@ class Operator(CharmBase):
         """Handles creating gateways from charm config
 
         Side effect: self.handle_ingress() is also invoked by this handler as ingress
-        objects depend on the default_gateway
+        resources depend on the default_gateway
         """
         t = self.env.get_template('gateway.yaml.j2')
         gateway = self.model.config['default-gateway']
         manifest = t.render(name=gateway, app_name=self.app.name)
-        self._resource_handler.delete_existing_resource_objects(
+        self._resource_handler.delete_existing_resources(
             resource=self._get_custom_resource_class(resource_name='gateway'),
             labels={
                 f"app.{self.app.name}.io/is-workload-entity": "true",
@@ -113,7 +113,7 @@ class Operator(CharmBase):
         )
         self._resource_handler.apply_manifest(manifest)
 
-        # Update the ingress objects as they rely on the default_gateway
+        # Update the ingress resources as they rely on the default_gateway
         self.handle_ingress(event)
 
     def send_info(self, event):
@@ -231,7 +231,7 @@ class Operator(CharmBase):
             for r in auth_routes
         )
 
-        self._resource_handler.delete_existing_resource_objects(
+        self._resource_handler.delete_existing_resources(
             self._get_custom_resource_class(resource_name='auth_filter'), namespace=self.model.name
         )
         self._resource_handler.apply_manifest(auth_filters, namespace=self.model.name)

--- a/charms/istio-pilot/src/resources_handler.py
+++ b/charms/istio-pilot/src/resources_handler.py
@@ -34,7 +34,7 @@ class ResourceHandler:
 
         self.env = Environment(loader=FileSystemLoader('src'))
 
-    def delete_object(
+    def delete_resource(
         self, obj, namespace=None, ignore_not_found=False, ignore_unauthorized=False
     ):
         try:
@@ -53,7 +53,7 @@ class ResourceHandler:
             else:
                 raise
 
-    def delete_existing_resource_objects(
+    def delete_existing_resources(
         self,
         resource,
         namespace=None,
@@ -68,7 +68,7 @@ class ResourceHandler:
             labels={"app.juju.is/created-by": f"{self.app_name}"}.update(labels),
             namespace=namespace,
         ):
-            self.delete_object(
+            self.delete_resource(
                 obj,
                 namespace=namespace,
                 ignore_not_found=ignore_not_found,
@@ -83,7 +83,7 @@ class ResourceHandler:
         self, manifest, namespace=None, ignore_not_found=False, ignore_unauthorized=False
     ):
         for obj in codecs.load_all_yaml(manifest):
-            self.delete_object(
+            self.delete_resource(
                 obj,
                 namespace=namespace,
                 ignore_not_found=ignore_not_found,
@@ -133,7 +133,7 @@ class ResourceHandler:
         Args:
             resource: resource kind (e.g. Service, Pod)
             desired_resources: all desired resources in manifest form as str
-            namespace: namespace of the object
+            namespace: namespace of the resource
         """
         existing_resources = self.lightkube_client.list(
             resource,
@@ -148,7 +148,7 @@ class ResourceHandler:
             desired_resources_list = codecs.load_all_yaml(desired_resources)
             diff_obj = in_left_not_right(left=existing_resources, right=desired_resources_list)
             for obj in diff_obj:
-                self.delete_object(obj)
+                self.delete_resource(obj)
             self.apply_manifest(desired_resources, namespace=namespace)
 
 

--- a/charms/istio-pilot/tests/unit/test_charm.py
+++ b/charms/istio-pilot/tests/unit/test_charm.py
@@ -19,12 +19,9 @@ def mocked_list(mocked_client, mocker):
         # 'unittest.mock.MagicMock does not seem possible. So when checking that the correct
         # resources are being deleted we will check the name of the object being deleted and just
         # use the the class name for obj.metadata.name
-        resource_obj = args[0]
-        print(resource_obj.metadata.__str__)
         mocked_metadata = mocker.MagicMock()
         mocked_metadata.name = str(args[0].__name__)
         mocked_resource_obj.metadata = mocked_metadata
-        mocked_resource_obj.kind = str(args[0].__name__)
         return [mocked_resource_obj]
 
     mocked_client.return_value.list.side_effect = side_effect

--- a/charms/istio-pilot/tests/unit/test_charm.py
+++ b/charms/istio-pilot/tests/unit/test_charm.py
@@ -373,9 +373,9 @@ def test_removal(harness, subprocess, mocked_client, helpers, mocker):
     # # ApiError with not found message should be ignored
     api_error.status.message = "something not found"
     mocked_client.return_value.delete.side_effect = api_error
-    # mock out the _delete_existing_resource_objects method since we dont want the ApiError
+    # mock out the _delete_existing_resources method since we dont want the ApiError
     # to be thrown there
-    mocker.patch('resources_handler.ResourceHandler.delete_existing_resource_objects')
+    mocker.patch('resources_handler.ResourceHandler.delete_existing_resources')
     # Ensure we DO NOT raise the exception
     harness.charm.on.remove.emit()
 

--- a/charms/istio-pilot/tests/unit/test_resources_handler.py
+++ b/charms/istio-pilot/tests/unit/test_resources_handler.py
@@ -38,7 +38,7 @@ def generate_pod_resource_list(pod_names):
         (  # 0 desired resources, M existing resources.  Delete: M calls.
             tuple(),  # Iterable of names of resources desired after reconciliation
             ("a", "b", "c"),  # Iterable of names of resources already on cluster before
-            ("a", "b", "c"),  # Names of resources expected to be passed to delete_object
+            ("a", "b", "c"),  # Names of resources expected to be passed to delete_resource
         ),
         (  # N desired, 0 existing resources.  Delete: 0 calls.
             ("a", "b", "c"),
@@ -73,8 +73,8 @@ def test_reconcile_desired_resources(
     ########################
     # Mock away dependencies
 
-    # Simplify checking object apply/delete actions
-    rh.delete_object = MagicMock()
+    # Simplify checking resource apply/delete actions
+    rh.delete_resource = MagicMock()
     rh.apply_manifest = MagicMock()
 
     # Attach our desired resources to a resource handler with a mocked lightkube client
@@ -110,7 +110,7 @@ def test_reconcile_desired_resources(
     )
 
     # Assert delete called for every element expected to be deleted
-    delete_calls = rh.delete_object.call_args_list
+    delete_calls = rh.delete_resource.call_args_list
     if delete_calls is None:
         delete_calls = tuple()
     names_deleted = tuple(c.args[0].metadata.name for c in delete_calls)
@@ -159,7 +159,7 @@ def test_in_left_not_right(left, right, expected_result):
     "resources,names_selected,context_raised",
     [
         (POD_LIST_1, ("pod-1", "pod-3"), does_not_raise()),  # Works
-        (POD_LIST_1, ("not-a-real-object",), pytest.raises(KeyError)),  # Missing element
+        (POD_LIST_1, ("not-a-real-resource",), pytest.raises(KeyError)),  # Missing element
         (POD_LIST_1 + POD_LIST_1, None, pytest.raises(ValueError)),  # Duplicate in resources
     ],
 )


### PR DESCRIPTION
In order to keep naming consistent across the charm code and [Lightkube](https://github.com/gtsystem/lightkube), we have decided to use the word "resources" instead of "object" in any method or var that handles Kubernetes resources.
These changes affect the charm code and the tests.