### PR TITLE
istio-pilot/src: refactors delete helper methods

### DIFF
--- a/charms/istio-pilot/charmcraft.yaml
+++ b/charms/istio-pilot/charmcraft.yaml
@@ -9,6 +9,7 @@ bases:
 parts:
   charm:
     charm-python-packages: [setuptools, pip]
+    build-packages: [git]
   istioctl:
     plugin: dump
     source: https://github.com/istio/istio/releases/download/1.11.0/istioctl-1.11.0-linux-amd64.tar.gz

--- a/charms/istio-pilot/requirements.txt
+++ b/charms/istio-pilot/requirements.txt
@@ -2,4 +2,5 @@ jinja2<3.1
 ops<1.4.0
 requests<2.27.0
 serialized-data-interface<0.4
-lightkube>=0.10.1
+#lightkube>=0.10.1
+git+https://github.com/ca-scribner/lightkube.git@add-implicit-model-generation#egg=lightkube

--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -96,7 +96,6 @@ class Operator(CharmBase):
             manifests,
             namespace=self.model.name,
             ignore_not_found=True,
-            include_created_by_external=True,
         )
 
     def handle_default_gateway(self, event):

--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -89,10 +89,14 @@ class Operator(CharmBase):
 
         for resource in self._custom_resource_classes.values():
             self._resource_handler.delete_existing_resources(
-                resource, namespace=self.model.name, ignore_unauthorized=True
+                resource,
+                namespace=self.model.name,
             )
         self._resource_handler.delete_manifest(
-            manifests, namespace=self.model.name, ignore_not_found=True, ignore_unauthorized=True
+            manifests,
+            namespace=self.model.name,
+            ignore_not_found=True,
+            include_created_by_external=True,
         )
 
     def handle_default_gateway(self, event):
@@ -252,7 +256,9 @@ class Operator(CharmBase):
         if resource_name not in self._custom_resource_classes:
             self._custom_resource_classes[
                 resource_name
-            ] = self._resource_handler.generate_generic_resource_class(f'{resource_name}.yaml.j2')
+            ] = self._resource_handler.generate_generic_resource_class(
+                f'{resource_name}.yaml.j2', from_filename=True
+            )
         return self._custom_resource_classes[resource_name]
 
     @property


### PR DESCRIPTION
Previously, we were not considering the case of deleting resources
created by other entities than lightkube, causing the remove event
handler to raise LoadResourceError exceptions (through helpers).
This commit handles that case and also refactors a couple other
helper methods to suit these needs.