### PR TITLE
test release charm action

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        charm-path:
+        charm:
           - charms/istio-pilot
           - charms/istio-gateway
     steps:
@@ -27,5 +27,7 @@ jobs:
       - uses: canonical/charmhub-upload-action@0.2.0
         with:
           credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
-          charm-path: ${{ matrix.charm-path }}
-          charmcraft-channel: latest/edge
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          charm-path: charms/${{ matrix.charm }}
+          channel: latest/edge
+          tag-prefix: ${{ matrix.charm }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,11 +20,11 @@ jobs:
       fail-fast: false
       matrix:
         charm:
-          - charms/istio-pilot
-          - charms/istio-gateway
+          - istio-pilot
+          - istio-gateway
     steps:
       - uses: actions/checkout@v2
-      - uses: canonical/charmhub-upload-action@0.2.0
+      - uses: canonical/charming-actions/upload-charm@1.0.0
         with:
           credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,33 @@
+name: Release charm to other tracks and channels
+
+on:
+  workflow_dispatch:
+    inputs:
+      destination-channel:
+        description: 'Destination Channel'
+        required: true
+      origin-channel:
+        description: 'Origin Channel'
+        required: false
+      rev:
+        description: 'Revision number'
+        required: false
+      tag-prefix:
+        description: 'Tag Prefix'
+        required: false
+
+jobs:
+  promote-charm:
+    name: Promote charm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Release charm to channel
+        uses: canonical/charming-actions/release-charm@promote-charm
+        with:
+          credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          destination-channel: ${{ github.event.inputs.destination-channel }}
+          origin-channel: ${{ github.event.inputs.origin-channel }}
+          revision: ${{ github.event.inputs.rev }}
+          tag-prefix: ${{ github.event.inputs.tag-prefix }}


### PR DESCRIPTION
Add new release charm action. Update publish action to use `upload-charm` as the release action need the release info from that action. 
It's using the release charm action from [promote-charm branch](https://github.com/canonical/charming-actions/tree/promote-charm). This would be updated in the future to use stable version