### PR TITLE
add charm path release action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,17 +4,17 @@ on:
   workflow_dispatch:
     inputs:
       destination-channel:
-        description: 'Destination Channel'
+        description: "Destination Channel"
         required: true
       origin-channel:
-        description: 'Origin Channel'
+        description: "Origin Channel"
         required: false
       rev:
-        description: 'Revision number'
+        description: "Revision number"
         required: false
       tag-prefix:
-        description: 'Tag Prefix'
-        required: false
+        description: "Tag Prefix"
+        required: true
 
 jobs:
   promote-charm:
@@ -31,3 +31,4 @@ jobs:
           origin-channel: ${{ github.event.inputs.origin-channel }}
           revision: ${{ github.event.inputs.rev }}
           tag-prefix: ${{ github.event.inputs.tag-prefix }}
+          charm-path: charms/${{ github.event.inputs.tag-prefix}}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,16 +4,16 @@ on:
   workflow_dispatch:
     inputs:
       destination-channel:
-        description: "Destination Channel"
+        description: 'Destination Channel'
         required: true
       origin-channel:
-        description: "Origin Channel"
+        description: 'Origin Channel'
         required: false
       rev:
-        description: "Revision number"
+        description: 'Revision number'
         required: false
-      tag-prefix:
-        description: "Tag Prefix"
+      charm-subdir-name:
+        description: 'Charm subdirectory name'
         required: true
 
 jobs:
@@ -30,5 +30,5 @@ jobs:
           destination-channel: ${{ github.event.inputs.destination-channel }}
           origin-channel: ${{ github.event.inputs.origin-channel }}
           revision: ${{ github.event.inputs.rev }}
-          tag-prefix: ${{ github.event.inputs.tag-prefix }}
-          charm-path: charms/${{ github.event.inputs.tag-prefix}}
+          tag-prefix: ${{ github.event.inputs.charm-subdir-name }}
+          charm-path: charms/${{ github.event.inputs.charm-subdir-name}}


### PR DESCRIPTION
Release action fails because it can't find `metadata.yaml` file in the directory. 
Provide charm-path to release action. Use tag-prefix as input as it is the same as the directory names. This way users have one less field to fill