### PR TITLE
Add SSL support

### DIFF
--- a/charms/istio-pilot/config.yaml
+++ b/charms/istio-pilot/config.yaml
@@ -3,3 +3,17 @@ options:
     type: string
     default: istio-gateway
     description: Name to use as a default gateway
+  ssl-crt:
+    type: string
+    default: ''
+    description: |
+        Base-64 certificate output. Can be set as follows:
+          $ juju config ssl-crt="$(cat CERT_FILE | base64 -w0)"
+        or on the bundle with: "include-base64://"
+  ssl-key:
+    type: string
+    default: ''
+    description: |
+        Base-64 key output. Can be set as follows:
+          $ juju config ssl-key="$(cat CERT_FILE | base64 -w0)"
+        or on the bundle with: "include-base64://"

--- a/charms/istio-pilot/src/gateway-secret.yaml.j2
+++ b/charms/istio-pilot/src/gateway-secret.yaml.j2
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ secret_name }}
+  namespace: {{ model_name }}
+  labels:
+    app.{{ app_name }}.io/is-workload-entity: "true"
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ ssl_crt }}
+  tls.key: {{ ssl_key }}

--- a/charms/istio-pilot/src/gateway.yaml.j2
+++ b/charms/istio-pilot/src/gateway.yaml.j2
@@ -25,14 +25,4 @@ spec:
     tls:
       mode: SIMPLE
       credentialName: {{ secret_name }}
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ secret_name }}
-  namespace: {{ model_name }}
-type: kubernetes.io/tls
-data:
-  tls.crt: {{ ssl_crt }}
-  tls.key: {{ ssl_key }}
 {% endif %}

--- a/charms/istio-pilot/src/gateway.yaml.j2
+++ b/charms/istio-pilot/src/gateway.yaml.j2
@@ -3,6 +3,7 @@ apiVersion: networking.istio.io/v1beta1
 kind: Gateway
 metadata:
   name: {{ name }}
+  namespace: {{ model_name }}
   labels:
     app.{{ app_name }}.io/is-workload-entity: "true"
 spec:
@@ -11,7 +12,27 @@ spec:
   servers:
   - hosts:
     - '*'
+{% if not secret_name %}
     port:
       name: http
       number: 80
       protocol: HTTP
+{% else %}
+    port:
+      name: https
+      number: 443
+      protocol: HTTPS
+    tls:
+      mode: SIMPLE
+      credentialName: {{ secret_name }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ secret_name }}
+  namespace: {{ model_name }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ ssl_crt }}
+  tls.key: {{ ssl_key }}
+{% endif %}

--- a/charms/istio-pilot/tox.ini
+++ b/charms/istio-pilot/tox.ini
@@ -27,5 +27,5 @@ commands =
 
 [testenv:lint]
 commands =
-    flake8 {[vars]all_path}
-    black --check {[vars]all_path}
+    flake8 {[vars]paths}
+    black --check --diff {[vars]paths}


### PR DESCRIPTION
Add ssl-* configs to pass cert and key. That should be
used to create a secret and added to the gateway yaml.

Added --diff to lint to show more details on tox.ini.