### PR TITLE
Small refactor on handle_ingress and _gateway_address

### DIFF
--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -135,12 +135,13 @@ class Operator(CharmBase):
 
     def handle_ingress(self, event):
         try:
-            if not self._get_gateway_address:
+            if not self._gateway_address:
                 self.log.info(
                     "No gateway address returned - this may be transitory, but "
                     "if it persists it is likely an unexpected error. "
                     "Deferring this event"
                 )
+                self.unit.status = WaitingStatus("Waiting for gateway address")
                 event.defer()
                 return
         except (ApiError, TypeError) as e:
@@ -153,6 +154,7 @@ class Operator(CharmBase):
             else:
                 self.log.exception("Unexpected exception, deferring this event.  Exception was:")
                 self.log.exception(e)
+            self.unit.status = BlockedStatus("Missing istio-ingressgateway relation")
             event.defer()
             return
 

--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -147,7 +147,7 @@ class Operator(CharmBase):
         except (ApiError, TypeError) as e:
             if isinstance(e, ApiError):
                 self.log.exception(
-                    "ApiError: Could not get istio-ingressgateway, deferring this event"
+                    "ApiError: Could not get istio-ingressgateway-workload, deferring this event"
                 )
             elif isinstance(e, TypeError):
                 self.log.exception("TypeError: No ip address found, deferring this event")
@@ -255,7 +255,7 @@ class Operator(CharmBase):
         self._resource_handler.apply_manifest(auth_filters, namespace=self.model.name)
 
     @property
-    def _get_gateway_address(self):
+    def _gateway_address(self):
         """Look up the load balancer address for the ingress gateway.
         If the gateway isn't available or doesn't have a load balancer address yet,
         returns None.
@@ -263,7 +263,7 @@ class Operator(CharmBase):
         # FIXME: service name is hardcoded
         # TODO: extract this from charm code
         svcs = self.lightkube_client.get(
-            Service, name="istio-ingressgateway", namespace=self.model.name
+            Service, name="istio-ingressgateway-workload", namespace=self.model.name
         )
         return svcs.status.loadBalancer.ingress[0].ip
 

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -50,7 +50,7 @@ async def test_deploy_istio_charms(ops_test: OpsTest):
     )
     await ops_test.model.deploy(
         istio_charms['istio-gateway'],
-        application_name='istio-gateway',
+        application_name='istio-ingressgateway',
         config={'kind': 'ingress'},
         trust=True,
     )

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -50,7 +50,7 @@ async def test_deploy_istio_charms(ops_test: OpsTest):
     )
     await ops_test.model.deploy(
         istio_charms['istio-gateway'],
-        application_name='istio-ingressgateway',
+        application_name='istio-gateway',
         config={'kind': 'ingress'},
         trust=True,
     )
@@ -59,8 +59,8 @@ async def test_deploy_istio_charms(ops_test: OpsTest):
 
     await ops_test.model.wait_for_idle(
         status="active",
-        raise_on_blocked=True,
-        timeout=60 * 10,
+        raise_on_blocked=False,
+        timeout=90 * 10,
     )
 
 


### PR DESCRIPTION
This PR slightly refactors the way we retrieve and check the ingressgateway address. First of all, since we recently changed the `Service` name in [this](https://github.com/canonical/istio-operators/commit/de0a9487fc7facf52567c7db93cdbf4433bcfc1d) commit, we have to reflect those changes on istio-pilot's code. Secondly, when we have a try/catch block that defers the event if there is not an ingressgateway address, but we were not setting the unit status and giving the correct messaging; the status was set to `Active` regardless.