### PR TITLE
Fixes for missing svc/istio-ingressgateway-workload

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -72,7 +72,7 @@ jobs:
 
     - name: Collect charmcraft logs
       if: failure()
-      run: cat /home/runner/snap/charmcraft/common/charmcraft-log-* | tee tmp/charmcraft.log
+      run: cat /home/runner/snap/charmcraft/common/cache/charmcraft/log/charmcraft-*.log | tee tmp/charmcraft.log
 
     - name: Collect Juju status
       if: failure()

--- a/charms/istio-gateway/charmcraft.yaml
+++ b/charms/istio-gateway/charmcraft.yaml
@@ -8,5 +8,5 @@ bases:
       channel: "20.04"
 parts:
   charm:
-    charm-python-packages: [setuptools, pip]
-
+    # Remove when pypa/setuptools_scm#713 gets fixed
+    charm-python-packages: [setuptools==62.1.0, pip==22.0.4]

--- a/charms/istio-gateway/requirements.txt
+++ b/charms/istio-gateway/requirements.txt
@@ -3,3 +3,4 @@ ops<1.4.0
 requests<2.27.0
 serialized-data-interface<0.4
 lightkube>=0.10.1
+oci-image

--- a/charms/istio-gateway/src/charm.py
+++ b/charms/istio-gateway/src/charm.py
@@ -5,7 +5,7 @@ import logging
 from jinja2 import Environment, FileSystemLoader
 from ops.charm import CharmBase
 from ops.main import main
-from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
+from ops.model import ActiveStatus, BlockedStatus, WaitingStatus, StatusBase
 from serialized_data_interface import NoCompatibleVersions, NoVersionsListed, get_interfaces
 from lightkube import Client, codecs
 from lightkube.core.exceptions import ApiError
@@ -15,34 +15,29 @@ class Operator(CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
 
-        if not self.unit.is_leader():
-            # We can't do anything useful when not the leader, so do nothing.
-            self.model.unit.status = WaitingStatus("Waiting for leadership")
-            return
-
-        try:
-            self.interfaces = get_interfaces(self)
-        except NoVersionsListed as err:
-            self.model.unit.status = WaitingStatus(str(err))
-            return
-        except NoCompatibleVersions as err:
-            self.model.unit.status = BlockedStatus(str(err))
-            return
-        else:
-            self.model.unit.status = ActiveStatus()
-
         self.log = logging.getLogger(__name__)
 
         # Every lightkube API call will use the model name as the namespace by default
         self.lightkube_client = Client(namespace=self.model.name, field_manager="lightkube")
 
-        self.framework.observe(self.on.start, self.start)
-        self.framework.observe(self.on["istio-pilot"].relation_changed, self.start)
-        self.framework.observe(self.on.config_changed, self.start)
+        for event in [
+            self.on.start,
+            self.on["istio-pilot"].relation_changed,
+            self.on.config_changed,
+        ]:
+            self.framework.observe(event, self.start)
         self.framework.observe(self.on.remove, self.remove)
 
     def start(self, event):
         """Event handler for StartEevnt."""
+        try:
+            self._check_leader()
+
+            interfaces = self._get_interfaces()
+
+        except CheckFailed as error:
+            self.model.unit.status = error.status
+            return
 
         if self.model.config['kind'] not in ('ingress', 'egress'):
             self.model.unit.status = BlockedStatus('Config item `kind` must be set')
@@ -52,7 +47,7 @@ class Operator(CharmBase):
             self.model.unit.status = BlockedStatus("Waiting for istio-pilot relation")
             return
 
-        if not ((pilot := self.interfaces["istio-pilot"]) and pilot.get_data()):
+        if not ((pilot := interfaces["istio-pilot"]) and pilot.get_data()):
             self.model.unit.status = WaitingStatus("Waiting for istio-pilot relation data")
             return
 
@@ -104,6 +99,30 @@ class Operator(CharmBase):
                     raise
             else:
                 raise
+
+    def _check_leader(self):
+        if not self.unit.is_leader():
+            raise CheckFailed("Waiting for leadership", WaitingStatus)
+
+    def _get_interfaces(self):
+        try:
+            interfaces = get_interfaces(self)
+        except NoVersionsListed as err:
+            raise CheckFailed(str(err), WaitingStatus)
+        except NoCompatibleVersions as err:
+            raise CheckFailed(str(err), BlockedStatus)
+        return interfaces
+
+
+class CheckFailed(Exception):
+    """Raise this exception if one of the checks in main fails."""
+
+    def __init__(self, msg, status_type=StatusBase):
+        super().__init__()
+
+        self.msg = str(msg)
+        self.status_type = status_type
+        self.status = status_type(self.msg)
 
 
 if __name__ == "__main__":

--- a/charms/istio-gateway/src/charm.py
+++ b/charms/istio-gateway/src/charm.py
@@ -48,7 +48,10 @@ class Operator(CharmBase):
             return
 
         if not ((pilot := interfaces["istio-pilot"]) and pilot.get_data()):
-            self.model.unit.status = WaitingStatus("Waiting for istio-pilot relation data")
+            self.model.unit.status = WaitingStatus(
+                "Waiting for istio-pilot relation data, deferring event"
+            )
+            event.defer()
             return
 
         pilot = list(pilot.get_data().values())[0]

--- a/charms/istio-gateway/tests/unit/test_charm.py
+++ b/charms/istio-gateway/tests/unit/test_charm.py
@@ -31,7 +31,7 @@ def test_events(configured_harness, mocker):
 
 
 def test_install_not_leader(harness):
-    harness.begin()
+    harness.begin_with_initial_hooks()
     assert harness.charm.model.unit.status == WaitingStatus('Waiting for leadership')
 
 

--- a/charms/istio-pilot/charmcraft.yaml
+++ b/charms/istio-pilot/charmcraft.yaml
@@ -8,7 +8,8 @@ bases:
       channel: "20.04"
 parts:
   charm:
-    charm-python-packages: [setuptools, pip]
+    # Remove when pypa/setuptools_scm#713 gets fixed
+    charm-python-packages: [setuptools==62.1.0, pip==22.0.4]
     build-packages: [git]
   istioctl:
     plugin: dump

--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -136,6 +136,11 @@ class Operator(CharmBase):
             event.defer()
 
     def handle_ingress(self, event):
+        # FIXME: sending the data every single time
+        # is not a great design, a better one involves refactoring and
+        # probably changing SDI
+        self.send_info(event)
+
         try:
             if not self._gateway_address:
                 self.log.info(

--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -23,7 +23,6 @@ class Operator(CharmBase):
             # We can't do anything useful when not the leader, so do nothing.
             self.model.unit.status = WaitingStatus("Waiting for leadership")
             return
-
         try:
             self.interfaces = get_interfaces(self)
         except NoVersionsListed as err:
@@ -132,6 +131,9 @@ class Operator(CharmBase):
             self.interfaces["istio-pilot"].send_data(
                 {"service-name": f'istiod.{self.model.name}.svc', "service-port": '15012'}
             )
+        else:
+            self.log.debug(f"Unable to send data, deferring event: {event}")
+            event.defer()
 
     def handle_ingress(self, event):
         try:
@@ -154,7 +156,9 @@ class Operator(CharmBase):
             else:
                 self.log.exception("Unexpected exception, deferring this event.  Exception was:")
                 self.log.exception(e)
-            self.unit.status = BlockedStatus("Missing istio-ingressgateway relation")
+            self.unit.status = WaitingStatus(
+                "Missing istio-ingressgateway-workload service, deferring this event"
+            )
             event.defer()
             return
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,4 +3,3 @@ aiohttp<3.8
 asyncio<3.5
 beautifulsoup4<4.11
 PyYAML==6.0
-cryptography==36.0.2

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,3 +3,4 @@ aiohttp<3.8
 asyncio<3.5
 beautifulsoup4<4.11
 PyYAML==6.0
+cryptography==36.0.2


### PR DESCRIPTION
`istio-gateway` has a strong dependency on `istio-pilot`'s relation data to actually create the k8s resources both of the charms need. This PR introduces changes that will ensure the data is sent, as well as the correct messaging and status is shown.