### PR TITLE
fix: remove incorrect argument from codecs.from_dict()

### DIFF
--- a/charms/istio-pilot/requirements.txt
+++ b/charms/istio-pilot/requirements.txt
@@ -7,4 +7,4 @@ oci-image
 # Temporarily using ca-scribner's branch that adds implicit custom
 # resource creation. Change this after those changes get merged into master
 #lightkube>=0.10.1
-git+https://github.com/ca-scribner/lightkube.git@add-implicit-model-generation#egg=lightkube
+git+https://github.com/ca-scribner/lightkube.git@30fe8ad5b9ce488946cedf39cf7624ef360df6f1

--- a/charms/istio-pilot/src/resources_handler.py
+++ b/charms/istio-pilot/src/resources_handler.py
@@ -11,6 +11,7 @@ import lightkube  # noqa F401  # Needed for patching in test_resources_handler.p
 from lightkube import Client, codecs
 from lightkube.core.exceptions import ApiError
 from lightkube.core.resource import Resource
+from lightkube.generic_resource import load_in_cluster_generic_resources
 
 
 class ResourceHandler:
@@ -29,6 +30,7 @@ class ResourceHandler:
 
         # Every lightkube API call will use the model name as the namespace by default
         self.lightkube_client = Client(namespace=self.model_name, field_manager="lightkube")
+        load_in_cluster_generic_resources(self.lightkube_client)
 
         self.env = Environment(loader=FileSystemLoader('src'))
 
@@ -117,7 +119,9 @@ class ResourceHandler:
             'service': 'service',
         }
         manifest = self.env.get_template(filename).render(context)
-        ns_resource = codecs.load_all_yaml(manifest, context=context, create_resources_for_crds=True)
+        ns_resource = codecs.load_all_yaml(
+            manifest, context=context, create_resources_for_crds=True
+        )
         return type(ns_resource[0])
 
     def reconcile_desired_resources(

--- a/charms/istio-pilot/src/resources_handler.py
+++ b/charms/istio-pilot/src/resources_handler.py
@@ -119,7 +119,7 @@ class ResourceHandler:
         }
         manifest = self.env.get_template(filename).render(context)
         manifest_dict = yaml.safe_load(manifest)
-        ns_resource = codecs.from_dict(manifest_dict, client=self.lightkube_client)
+        ns_resource = codecs.from_dict(manifest_dict)
         return type(ns_resource)
 
     def reconcile_desired_resources(

--- a/charms/istio-pilot/src/resources_handler.py
+++ b/charms/istio-pilot/src/resources_handler.py
@@ -6,7 +6,6 @@
 import logging
 from typing import Tuple, TextIO, Union, Iterable
 
-import yaml
 from jinja2 import Environment, FileSystemLoader
 import lightkube  # noqa F401  # Needed for patching in test_resources_handler.py
 from lightkube import Client, codecs
@@ -118,9 +117,8 @@ class ResourceHandler:
             'service': 'service',
         }
         manifest = self.env.get_template(filename).render(context)
-        manifest_dict = yaml.safe_load(manifest)
-        ns_resource = codecs.from_dict(manifest_dict)
-        return type(ns_resource)
+        ns_resource = codecs.load_all_yaml(manifest, context=context, create_resources_for_crds=True)
+        return type(ns_resource[0])
 
     def reconcile_desired_resources(
         self,

--- a/charms/istio-pilot/tests/unit/test_resources_handler.py
+++ b/charms/istio-pilot/tests/unit/test_resources_handler.py
@@ -94,14 +94,15 @@ PODS_TO_DELETE = [
 
 
 def test_delete_existing_resource(mocked_client):
-    with mock.patch("resources_handler.ResourceHandler.delete_resource") as mock_delete:
+    with mock.patch(
+        "resources_handler.ResourceHandler.delete_resource"
+    ) as mock_delete, mock.patch('resources_handler.load_in_cluster_generic_resources'):
         mock_list = mocked_client.return_value.list
         mock_list.return_value = PODS_TO_DELETE
         ResourceHandler(APP_NAME, MODEL_NAME).delete_existing_resources(
             Pod, namespace="some-namespace", labels=None
         )
         deleted_resources = [item.args[0] for item in mock_delete.call_args_list]
-
         assert deleted_resources == PODS_TO_DELETE
 
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,5 @@
+# Remove once python-libjuju>2.9.10 is released
+git+https://github.com/juju/python-libjuju@master
 pytest-operator<1.0
 aiohttp<3.8
 asyncio<3.5

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,3 @@
-# Remove once python-libjuju>2.9.10 is released
-git+https://github.com/juju/python-libjuju@master
 pytest-operator<1.0
 aiohttp<3.8
 asyncio<3.5


### PR DESCRIPTION
This PR introduces the following:
* refactor: use load_all_yaml with create_resources_for_crds as True
Due to [recent changes](https://github.com/gtsystem/lightkube/pull/34/commits/4446c4093698637d646b57e37a021abe9da1ef6d) in the Lightkube API, in particular the branch we are using temporarily, we have to use load_all_yaml instead of from_dict to obtain the class of custom generic resources.
* fix: remove incorrect argument from codecs.from_dict()
Lightkube's [`codecs.from_dict()`](https://github.com/gtsystem/lightkube/blob/master/lightkube/codecs.py#L43) does not accept the client arg. This commit removes it to avoid this error:

```
2022-07-07 19:44:10,396 ERROR    Uncaught exception while in charm code:
Traceback (most recent call last):
  File "./src/charm.py", line 334, in <module>
    main(Operator)
  File "/var/lib/juju/agents/unit-istio-pilot-0/charm/venv/ops/main.py", line 426, in main
    _emit_charm_event(charm, dispatcher.event_name)
  File "/var/lib/juju/agents/unit-istio-pilot-0/charm/venv/ops/main.py", line 142, in _emit_charm_event
    event_to_emit.emit(*args, **kwargs)
  File "/var/lib/juju/agents/unit-istio-pilot-0/charm/venv/ops/framework.py", line 276, in emit
    framework._emit(event)
  File "/var/lib/juju/agents/unit-istio-pilot-0/charm/venv/ops/framework.py", line 736, in _emit
    self._reemit(event_path)
  File "/var/lib/juju/agents/unit-istio-pilot-0/charm/venv/ops/framework.py", line 783, in _reemit
    custom_handler(event)
  File "./src/charm.py", line 118, in handle_default_gateway
    resource=self._resource_handler.get_custom_resource_class_from_filename(
  File "/var/lib/juju/agents/unit-istio-pilot-0/charm/src/resources_handler.py", line 122, in get_custom_resource_class_from_filenam
e
    ns_resource = codecs.from_dict(manifest_dict, client=self.lightkube_client)
TypeError: from_dict() got an unexpected keyword argument 'client'
```