### PR TITLE
Add LIBID to published library

### DIFF
--- a/charms/istio-pilot/lib/charms/istio_pilot/v0/istio_gateway_name.py
+++ b/charms/istio-pilot/lib/charms/istio_pilot/v0/istio_gateway_name.py
@@ -42,6 +42,9 @@ import logging
 from ops.framework import Object
 from ops.model import Application
 
+# The unique Charmhub library identifier, never change it
+LIBID = "0eb026ea5857413a9ed89f7740a6b03d"
+
 # Increment this major API version when introducing breaking changes
 LIBAPI = 0
 
@@ -119,3 +122,4 @@ class GatewayRequirer(Object):
             "gateway_name": data["gateway_name"],
             "gateway_namespace": data["gateway_namespace"],
         }
+


### PR DESCRIPTION
To comply with charmcraft library requirements and publish it to charmhub, `LIBID` had to be added to `istio_gateway_name.py`.