### PR TITLE
fix: bind handle_default_gateway to ingress_relation_created

### DIFF
--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -51,7 +51,8 @@ class Operator(CharmBase):
         self.framework.observe(self.on.install, self.install)
         self.framework.observe(self.on.remove, self.remove)
 
-        self.framework.observe(self.on.config_changed, self.handle_default_gateway)
+        for event in [self.on.config_changed, self.on["ingress"].relation_created]:
+            self.framework.observe(event, self.handle_default_gateway)
 
         self.framework.observe(
             self.on[DEFAULT_RELATION_NAME].relation_changed, self.handle_default_gateway

--- a/charms/istio-pilot/tests/unit/test_charm.py
+++ b/charms/istio-pilot/tests/unit/test_charm.py
@@ -64,7 +64,7 @@ def test_events(harness, mocker):
         "app",
         {"some_key": "some_value"},
     )
-    handle_ingress.assert_called_once()
+    handle_ingress.assert_called()
     handle_ingress.reset_mock()
 
     harness.add_relation_unit(rel_id, "app/0")


### PR DESCRIPTION
The handle_default_gateway method is not run on config_changed at deployment time,
this is an unexpected behaviour that happens when istio-pilot is related to
multiple other charms in a bundle. Although config_changed is guaranteed to
run after install, that is not the case under the described conditions, causing
the default gateway to not be created without human intervention.
To avoid this situation, and given that istio-pilot is usually deployed in a bundle
and related to multiple charms, the handle_default_gateway method can be also bound to
["ingress"].relation_created, which is also guaranteed to run after install.

Fixes: canonical/istio-operators#94