### PR TITLE
cannon/change-fbbc98f8

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -23,7 +23,7 @@ jobs:
       with:
         fetch-depth: 0
     - name: Check libs
-      uses: canonical/charming-actions/check-libraries@1.0.3
+      uses: canonical/charming-actions/check-libraries@2.0.0-rc
       with:
         charm-path: ./charms/${{ matrix.charm }}
         credentials: "${{ secrets.charmcraft-credentials }}"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -24,10 +24,10 @@ jobs:
         with:
           fetch-depth: 0
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@1.0.3
+        uses: canonical/charming-actions/channel@2.0.0-rc
         id: channel
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@1.0.3
+        uses: canonical/charming-actions/upload-charm@2.0.0-rc
         with:
           credentials: ${{ secrets.charmcraft-credentials }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Release charm to channel
-        uses: canonical/charming-actions/release-charm@1.0.3
+        uses: canonical/charming-actions/release-charm@2.0.0-rc
         with:
           credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Changes applied by commit-cannon:
  * Replaced text `canonical/charming-actions/release-charm@1.0.3` with `canonical/charming-actions/release-charm@2.0.0-rc` in `.github/workflows/release.yaml`
  * Replaced text `canonical/charming-actions/channel@1.0.3` with `canonical/charming-actions/channel@2.0.0-rc` in `.github/workflows/publish.yaml`
  * Replaced text `canonical/charming-actions/upload-charm@1.0.3` with `canonical/charming-actions/upload-charm@2.0.0-rc` in `.github/workflows/publish.yaml`
  * Replaced text `canonical/charming-actions/check-libraries@1.0.3` with `canonical/charming-actions/check-libraries@2.0.0-rc` in `.github/workflows/integration.yaml`
