### PR TITLE
Temporal fixes for sending gateway information through relations 

### DIFF
--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -158,10 +158,13 @@ class Operator(CharmBase):
         # Update the ingress resources as they rely on the default_gateway
         self.handle_ingress(event)
 
-        # check if gateway is created
-        self.handle_gateway_relation(event)
-
     def handle_gateway_relation(self, event):
+        if self.model.relations["gateway"]:
+            self.log.info(
+                "No gateway relation found, waiting for remote unit to join the relation"
+            )
+            self.unit.status = WaitingStatus("Waiting for remote unit to join gateway relation")
+            return
         is_gateway_created = self._resource_handler.validate_resource_exist(
             resource_type=self._resource_handler.get_custom_resource_class_from_filename(
                 "gateway.yaml.j2"

--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -54,9 +54,11 @@ class Operator(CharmBase):
         for event in [self.on.config_changed, self.on["ingress"].relation_created]:
             self.framework.observe(event, self.handle_default_gateway)
 
-        self.framework.observe(
-            self.on[DEFAULT_RELATION_NAME].relation_changed, self.handle_default_gateway
-        )
+        # FIXME: Calling handle_gateway_relation on update_status ensures gateway information is
+        # sent eventually to the related units, this is temporal and we should find a way to
+        # ensure all event handlers are called when they are supposed to.
+        for event in [self.on[DEFAULT_RELATION_NAME].relation_changed, self.on.update_status]:
+            self.framework.observe(event, self.handle_gateway_relation)
         self.framework.observe(self.on["istio-pilot"].relation_changed, self.send_info)
         self.framework.observe(self.on['ingress'].relation_changed, self.handle_ingress)
         self.framework.observe(self.on['ingress'].relation_broken, self.handle_ingress)


### PR DESCRIPTION
This PR introduces the following changes:
  * fix: add a check for gateway relation to avoid sending data when units haven't joined  
  * fix: bind handle_gateway_relation to update_status and handle_gateway_relation
    
    When deployed in a bundle with a large number of charms,
    it seems like the istio-pilot charm cannot handle all the
    relations correctly at the same time. Binding handle_gateway_relation
    to update_status ensures that at least gateway_data is sent eventually.