### PR TITLE
 Temporal fixes for sending gateway information through relations

### DIFF
--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -158,10 +158,10 @@ class Operator(CharmBase):
         # Update the ingress resources as they rely on the default_gateway
         self.handle_ingress(event)
 
-        # check if gateway is created
-        self.handle_gateway_relation(event)
-
     def handle_gateway_relation(self, event):
+        if not self.model.relations["gateway"]:
+            self.log.info("No gateway relation found")
+            return
         is_gateway_created = self._resource_handler.validate_resource_exist(
             resource_type=self._resource_handler.get_custom_resource_class_from_filename(
                 "gateway.yaml.j2"

--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -54,9 +54,11 @@ class Operator(CharmBase):
         for event in [self.on.config_changed, self.on["ingress"].relation_created]:
             self.framework.observe(event, self.handle_default_gateway)
 
-        self.framework.observe(
-            self.on[DEFAULT_RELATION_NAME].relation_changed, self.handle_default_gateway
-        )
+        # FIXME: Calling handle_gateway_relation on update_status ensures gateway information is
+        # sent eventually to the related units, this is temporal and we should find a way to
+        # ensure all event handlers are called when they are supposed to.
+        for event in [self.on[DEFAULT_RELATION_NAME].relation_changed, self.on.update_status]:
+            self.framework.observe(event, self.handle_gateway_relation)
         self.framework.observe(self.on["istio-pilot"].relation_changed, self.send_info)
         self.framework.observe(self.on['ingress'].relation_changed, self.handle_ingress)
         self.framework.observe(self.on['ingress'].relation_broken, self.handle_ingress)

--- a/charms/istio-pilot/tests/unit/test_charm.py
+++ b/charms/istio-pilot/tests/unit/test_charm.py
@@ -361,17 +361,19 @@ def test_correct_data_in_gateway_relation(harness, mocker, mocked_client):
     )
     mocked_validate_gateway.return_value = True
 
-    rel_id = harness.add_relation("gateway", "app")
-    harness.add_relation_unit(rel_id, "app/0")
     harness.set_model_name("test-model")
     mocker.patch('resources_handler.load_in_cluster_generic_resources')
-    harness.begin_with_initial_hooks()
 
-    gateway_relations = harness.model.relations["gateway"]
-    istio_relation_data = gateway_relations[0].data[harness.model.app]
+    rel_id = harness.add_relation("gateway", "app")
+    harness.add_relation_unit(rel_id, "app/0")
+
+    harness.begin_with_initial_hooks()
+    model = harness.charm.framework.model
+    gateway_relations = model.get_relation("gateway", rel_id)
+    istio_relation_data = gateway_relations.data[harness.charm.app]
 
     assert istio_relation_data["gateway_name"] == harness.model.config["default-gateway"]
-    assert istio_relation_data["gateway_namespace"] == harness.model.name
+    assert istio_relation_data["gateway_namespace"] == model.name
 
 
 def test_removal(harness, subprocess, mocked_client, helpers, mocker):


### PR DESCRIPTION
This PR introduces the following changes:
  * fix: add a check for gateway relation to avoid sending data when units haven't joined  
  * fix: bind handle_gateway_relation to update_status and handle_gateway_relation
    
    When deployed in a bundle with a large number of charms,
    it seems like the istio-pilot charm cannot handle all the
    relations correctly at the same time. Binding handle_gateway_relation
    to update_status ensures that at least gateway_data is sent eventually.