### PR TITLE
refactor: renames gateway relation and gateway-name interface

### DIFF
--- a/charms/istio-pilot/lib/charms/istio_pilot/v0/istio_gateway_info.py
+++ b/charms/istio-pilot/lib/charms/istio_pilot/v0/istio_gateway_info.py
@@ -10,19 +10,19 @@ gateway information.
 You can fetch the library using the following commands with charmcraft.
 ```shell
 cd some-charm
-charmcraft fetch-lib charms.istio_pilot.v0.istio_gateway_name
+charmcraft fetch-lib charms.istio_pilot.v0.istio_gateway_info
 ```
 ### Add relation to metadata.yaml
 ```yaml
 requires:
-    gateway:
-        interface: istio_gateway_name
+    gateway-info:
+        interface: istio_gateway_info
         limit: 1
 ```
 
 ### Initialise the library in charm.py
 ```python
-from charms.istio_pilot.v0.istio_gateway_name import GatewayProvider, GatewayRelationError
+from charms.istio_pilot.v0.istio_gateway_info import GatewayProvider, GatewayRelationError
 
 Class SomeCharm(CharmBase):
     def __init__(self, *args):
@@ -50,11 +50,11 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 
-DEFAULT_RELATION_NAME = "gateway"
-DEFAULT_INTERFACE_NAME = "istio-gateway-name"
+RELATION_NAME = "gateway-info"
+INTERFACE_NAME = "istio-gateway-info"
 
 logger = logging.getLogger(__name__)
 
@@ -65,13 +65,13 @@ class GatewayRelationError(Exception):
 
 class GatewayRelationMissingError(GatewayRelationError):
     def __init__(self):
-        self.message = "Missing gateway relation with istio-pilot"
+        self.message = "Missing gateway-info relation with istio-pilot"
         super().__init__(self.message)
 
 
 class GatewayRelationTooManyError(GatewayRelationError):
     def __init__(self):
-        self.message = "Too many istio-gateway-name relations"
+        self.message = "Too many istio-gateway-info relations"
         super().__init__(self.message)
 
 
@@ -82,7 +82,7 @@ class GatewayRelationDataMissingError(GatewayRelationError):
 
 
 class GatewayRequirer(Object):
-    def __init__(self, charm, relation_name: str = DEFAULT_RELATION_NAME):
+    def __init__(self, charm, relation_name: str = RELATION_NAME):
         super().__init__(charm, relation_name)
         self.charm = charm
         self.relation_name = relation_name
@@ -106,16 +106,16 @@ class GatewayRequirer(Object):
 
         if not "gateway_name" in data:
             logger.error(
-                "Missing gateway name in gateway relation data. Waiting for gateway creation in istio-pilot"
+                "Missing gateway name in gateway-info relation data. Waiting for gateway creation in istio-pilot"
             )
             raise GatewayRelationDataMissingError(
-                "Missing gateway name in gateway relation data. Waiting for gateway creation in istio-pilot"
+                "Missing gateway name in gateway-info relation data. Waiting for gateway creation in istio-pilot"
             )
 
         if not "gateway_namespace" in data:
-            logger.error("Missing gateway namespace in gateway relation data")
+            logger.error("Missing gateway namespace in gateway-info relation data")
             raise GatewayRelationDataMissingError(
-                "Missing gateway namespace in gateway relation data"
+                "Missing gateway namespace in gateway-info relation data"
             )
 
         return {

--- a/charms/istio-pilot/metadata.yaml
+++ b/charms/istio-pilot/metadata.yaml
@@ -17,8 +17,8 @@ provides:
     interface: ingress-auth
     schema: https://raw.githubusercontent.com/canonical/operator-schemas/master/ingress-auth.yaml
     versions: [v1]
-  gateway:
-    interface: istio-gateway-name
+  gateway-info:
+    interface: istio-gateway-info
     description: |
       Provides gateway name related Juju application
 assumes:

--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -13,7 +13,7 @@ from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from serialized_data_interface import NoCompatibleVersions, NoVersionsListed, get_interfaces
 from resources_handler import ResourceHandler
-from istio_gateway_name_provider import GatewayProvider, DEFAULT_RELATION_NAME
+from istio_gateway_info_provider import GatewayProvider, RELATION_NAME
 
 
 class Operator(CharmBase):
@@ -57,8 +57,8 @@ class Operator(CharmBase):
         # FIXME: Calling handle_gateway_relation on update_status ensures gateway information is
         # sent eventually to the related units, this is temporal and we should find a way to
         # ensure all event handlers are called when they are supposed to.
-        for event in [self.on[DEFAULT_RELATION_NAME].relation_changed, self.on.update_status]:
-            self.framework.observe(event, self.handle_gateway_relation)
+        for event in [self.on[RELATION_NAME].relation_changed, self.on.update_status]:
+            self.framework.observe(event, self.handle_gateway_info_relation)
         self.framework.observe(self.on["istio-pilot"].relation_changed, self.send_info)
         self.framework.observe(self.on['ingress'].relation_changed, self.handle_ingress)
         self.framework.observe(self.on['ingress'].relation_broken, self.handle_ingress)
@@ -158,9 +158,9 @@ class Operator(CharmBase):
         # Update the ingress resources as they rely on the default_gateway
         self.handle_ingress(event)
 
-    def handle_gateway_relation(self, event):
-        if not self.model.relations["gateway"]:
-            self.log.info("No gateway relation found")
+    def handle_gateway_info_relation(self, event):
+        if not self.model.relations["gateway-info"]:
+            self.log.info("No gateway-info relation found")
             return
         is_gateway_created = self._resource_handler.validate_resource_exist(
             resource_type=self._resource_handler.get_custom_resource_class_from_filename(

--- a/charms/istio-pilot/src/istio_gateway_info_provider.py
+++ b/charms/istio-pilot/src/istio_gateway_info_provider.py
@@ -3,15 +3,15 @@ from ops.framework import Object
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_RELATION_NAME = "gateway"
+RELATION_NAME = "gateway-info"
 
 
 class GatewayProvider(Object):
-    def __init__(self, charm, relation_name=DEFAULT_RELATION_NAME):
+    def __init__(self, charm, relation_name=RELATION_NAME):
         super().__init__(charm, relation_name)
 
     def send_gateway_relation_data(self, charm, gateway_name, gateway_namespace):
-        relations = self.model.relations["gateway"]
+        relations = self.model.relations["gateway-info"]
         for relation in relations:
             relation.data[charm].update(
                 {

--- a/charms/istio-pilot/tests/unit/test_charm.py
+++ b/charms/istio-pilot/tests/unit/test_charm.py
@@ -345,7 +345,7 @@ def test_with_ingress_auth_relation(harness, subprocess, helpers, mocked_client,
     assert isinstance(harness.charm.model.unit.status, ActiveStatus)
 
 
-def test_correct_data_in_gateway_relation(harness, mocker, mocked_client):
+def test_correct_data_in_gateway_info_relation(harness, mocker, mocked_client):
     harness.set_leader(True)
 
     create_global_resource(
@@ -364,12 +364,12 @@ def test_correct_data_in_gateway_relation(harness, mocker, mocked_client):
     harness.set_model_name("test-model")
     mocker.patch('resources_handler.load_in_cluster_generic_resources')
 
-    rel_id = harness.add_relation("gateway", "app")
+    rel_id = harness.add_relation("gateway-info", "app")
     harness.add_relation_unit(rel_id, "app/0")
 
     harness.begin_with_initial_hooks()
     model = harness.charm.framework.model
-    gateway_relations = model.get_relation("gateway", rel_id)
+    gateway_relations = model.get_relation("gateway-info", rel_id)
     istio_relation_data = gateway_relations.data[harness.charm.app]
 
     assert istio_relation_data["gateway_name"] == harness.model.config["default-gateway"]


### PR DESCRIPTION
The relation and interface name `gateway`  and `istio-gateway-name` are very ambiguous and generic, and could lead to confusion.
This PR renames all instances of gateway and istio-gateway-name, including those in the lib. Please NOTE following this PR we MUST update the lib in Charmhub with `charmcraft push-lib` after this PR is merged.

Blocks: [PR#27](https://github.com/canonical/kubeflow-tensorboards-operator/pull/27), [PR#486](https://github.com/canonical/bundle-kubeflow/pull/486)