### PR TITLE
Update `ingress-auth` relation to only restrict traffic on the Kubeflow ingress

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -84,6 +84,11 @@ jobs:
         sg microk8s -c 'juju bootstrap microk8s uk8s'
         sg microk8s -c 'juju add-model istio-system'
 
+    # DEBUG
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 60
+
     - run: sg microk8s -c 'KUBECONFIG=/home/runner/.kube/config tox -e integration
         -- --model istio-system --destructive-mode'
       timeout-minutes: 25

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -60,7 +60,8 @@ jobs:
 
     - uses: balchua/microk8s-actions@v0.2.2
       with:
-        channel: 'latest/stable'
+        # TODO: Pinned to <1.25 until we update to istio 1.15
+        channel: '1.24/stable'
         addons: '["dns", "storage", "rbac", "metallb:10.64.140.43-10.64.140.49"]'
 
     - name: Install dependencies

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -85,11 +85,6 @@ jobs:
         sg microk8s -c 'juju bootstrap microk8s uk8s'
         sg microk8s -c 'juju add-model istio-system'
 
-    # DEBUG
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
-      timeout-minutes: 180
-
     - run: sg microk8s -c 'KUBECONFIG=/home/runner/.kube/config tox -e integration
         -- --model istio-system --destructive-mode'
       timeout-minutes: 25

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -87,7 +87,7 @@ jobs:
     # DEBUG
     - name: Setup tmate session
       uses: mxschmitt/action-tmate@v3
-      timeout-minutes: 60
+      timeout-minutes: 180
 
     - run: sg microk8s -c 'KUBECONFIG=/home/runner/.kube/config tox -e integration
         -- --model istio-system --destructive-mode'

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -87,7 +87,7 @@ jobs:
 
     - run: sg microk8s -c 'KUBECONFIG=/home/runner/.kube/config tox -e integration
         -- --model istio-system --destructive-mode'
-      timeout-minutes: 25
+      timeout-minutes: 40
 
     - name: Setup Debug Artifact Collection
       run: mkdir tmp

--- a/charms/istio-pilot/src/auth_filter.yaml.j2
+++ b/charms/istio-pilot/src/auth_filter.yaml.j2
@@ -11,6 +11,7 @@ spec:
       match:
         context: GATEWAY
         listener:
+          portNumber: {{ gateway_port }}
           filterChain:
             filter:
               name: "envoy.filters.network.http_connection_manager"

--- a/charms/istio-pilot/src/gateway.yaml.j2
+++ b/charms/istio-pilot/src/gateway.yaml.j2
@@ -15,12 +15,12 @@ spec:
 {% if not secret_name %}
     port:
       name: http
-      number: 80
+      number: {{ gateway_http_port }}
       protocol: HTTP
 {% else %}
     port:
       name: https
-      number: 443
+      number: {{ gateway_https_port }}
       protocol: HTTPS
     tls:
       mode: SIMPLE

--- a/charms/istio-pilot/tests/unit/test_charm.py
+++ b/charms/istio-pilot/tests/unit/test_charm.py
@@ -286,7 +286,7 @@ def test_with_ingress_auth_relation(harness, subprocess, helpers, mocked_client,
                                     'filter': {
                                         'name': 'envoy.filters.network.http_connection_manager'
                                     }
-                                }
+                                },
                             },
                         },
                         'patch': {

--- a/charms/istio-pilot/tests/unit/test_charm.py
+++ b/charms/istio-pilot/tests/unit/test_charm.py
@@ -281,6 +281,7 @@ def test_with_ingress_auth_relation(harness, subprocess, helpers, mocked_client,
                         'match': {
                             'context': 'GATEWAY',
                             'listener': {
+                                'portNumber': 8080,
                                 'filterChain': {
                                     'filter': {
                                         'name': 'envoy.filters.network.http_connection_manager'

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,6 @@
-pytest-operator<1.0
 aiohttp<3.8
 asyncio<3.5
 beautifulsoup4<4.11
 PyYAML==6.0
+lightkube
+pytest-operator<1.0

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -1,13 +1,28 @@
 import json
 import logging
+from pathlib import Path
+import requests
+from time import sleep
+import yaml
 
 import aiohttp
-import pytest
-import yaml
 from bs4 import BeautifulSoup as BS
+import lightkube
+from lightkube import codecs
+from lightkube.generic_resource import load_in_cluster_generic_resources
+import pytest
 from pytest_operator.plugin import OpsTest
 
 log = logging.getLogger(__name__)
+
+
+DEX_AUTH = "dex-auth"
+OIDC_GATEKEEPER = "oidc-gatekeeper"
+ISTIO_PILOT = "istio-pilot"
+ISTIO_GATEWAY_APP_NAME = "istio-gateway"
+
+USERNAME = "user123"
+PASSWORD = "user123"
 
 
 @pytest.mark.abort_on_fail
@@ -46,16 +61,18 @@ async def test_deploy_istio_charms(ops_test: OpsTest):
     istio_charms = await ops_test.build_charms(f"{charms_path}-gateway", f"{charms_path}-pilot")
 
     await ops_test.model.deploy(
-        istio_charms['istio-pilot'], application_name='istio-pilot', trust=True
+        istio_charms['istio-pilot'], application_name=ISTIO_PILOT, trust=True
     )
     await ops_test.model.deploy(
         istio_charms['istio-gateway'],
-        application_name='istio-gateway',
+        application_name=ISTIO_GATEWAY_APP_NAME,
         config={'kind': 'ingress'},
         trust=True,
     )
 
-    await ops_test.model.add_relation("istio-pilot:istio-pilot", "istio-gateway:istio-pilot")
+    await ops_test.model.add_relation(
+        f"{ISTIO_PILOT}:istio-pilot", f"{ISTIO_GATEWAY_APP_NAME}:istio-pilot"
+    )
 
     await ops_test.model.wait_for_idle(
         status="active",
@@ -64,13 +81,23 @@ async def test_deploy_istio_charms(ops_test: OpsTest):
     )
 
 
+@pytest.mark.abort_on_fail
 async def test_deploy_bookinfo_example(ops_test: OpsTest):
     root_url = 'https://raw.githubusercontent.com/istio/istio/release-1.11/samples/bookinfo'
+    bookinfo_namespace = f'{ops_test.model_name}-bookinfo'
+
+    await ops_test.run(
+        'kubectl',
+        'create',
+        'namespace',
+        bookinfo_namespace,
+    )
+
     await ops_test.run(
         'kubectl',
         'label',
         'namespace',
-        'default',
+        bookinfo_namespace,
         'istio-injection=enabled',
         '--overwrite=true',
         check=True,
@@ -82,8 +109,11 @@ async def test_deploy_bookinfo_example(ops_test: OpsTest):
         f'{root_url}/platform/kube/bookinfo.yaml',
         '-f',
         f'{root_url}/networking/bookinfo-gateway.yaml',
+        "--namespace",
+        bookinfo_namespace,
         check=True,
     )
+
     await ops_test.run(
         'kubectl',
         'wait',
@@ -103,12 +133,12 @@ async def test_deploy_bookinfo_example(ops_test: OpsTest):
         '--for=condition=ready',
         'pod',
         '--all',
-        '-n=default',
+        f'-n={bookinfo_namespace}',
         '--timeout=5m',
         check=True,
     )
 
-    gateway_ip = get_gateway_ip(ops_test)
+    gateway_ip = await get_gateway_ip(ops_test)
     async with aiohttp.ClientSession(raise_for_status=True) as client:
         results = await client.get(f'http://{gateway_ip}/productpage')
         soup = BS(await results.text())
@@ -116,12 +146,112 @@ async def test_deploy_bookinfo_example(ops_test: OpsTest):
     assert soup.title.string == 'Simple Bookstore App'
 
 
+async def test_ingress_auth(ops_test: OpsTest):
+    """Tests that the ingress auth policy restricts traffic on (only the) kubeflow gateway.
+
+    This test establishes the ingress-auth relation, which applies an auth policy to traffic
+    through port 80/8080 on the gateway (the port opened for external traffic through the ingress).
+    We test that unauthenticated traffic over port 80/8080 is restricted (eg: returns a 302 because
+    it is redirected to dex).
+
+    With the above auth restriction enabled, we also test that other routes through the gateway
+    are not restricted.  This is tested by (through kubernetes manifests) creating a second
+    ingress pathway using a different port (8081) in the istio-ingressgatway workload and
+    verifying that traffic over that port does not get redirected to dex.  This test simulates
+    similar behaviour to what is used in Knative's local gateway
+
+    This test uses the bookinfo application from a previous test and must be run after that test.
+    TODO:
+    * Remove the bookinfo application, and just use a second simpler deployment
+    * deploy/clean up deployments using fixtures?
+    """
+    # Deploy a secondary workload that also uses the istio proxy deployment (istio-ingressgateway),
+    # but through a different port
+    namespace = ops_test.model_name
+    gateway_port = 8081
+    test_workload_name = "secondary-ingress-test"
+    deploy_workload_with_gateway(
+        workload_name=test_workload_name, gateway_port=gateway_port, namespace=namespace
+    )
+
+    # Deploy everything needed to implement the ingress-auth relation
+    regular_ingress_gateway_ip = await get_gateway_ip(ops_test)
+    await ops_test.model.deploy(
+        DEX_AUTH,
+        channel="2.31/stable",
+        trust=True,
+        config={
+            "static-username": USERNAME,
+            "static-password": PASSWORD,
+            "public-url": regular_ingress_gateway_ip,
+        },
+    )
+
+    await ops_test.model.deploy(
+        OIDC_GATEKEEPER,
+        channel="ckf-1.6/stable",
+        config={"public-url": regular_ingress_gateway_ip},
+    )
+
+    await ops_test.model.add_relation(f"{ISTIO_PILOT}:ingress", f"{DEX_AUTH}:ingress")
+    await ops_test.model.add_relation(f"{ISTIO_PILOT}:ingress", f"{OIDC_GATEKEEPER}:ingress")
+    await ops_test.model.add_relation(f"{OIDC_GATEKEEPER}:oidc-client", f"{DEX_AUTH}:oidc-client")
+    await ops_test.model.add_relation(
+        f"{ISTIO_PILOT}:ingress-auth", f"{OIDC_GATEKEEPER}:ingress-auth"
+    )
+
+    # Wait for the oidc/dex charms to become active
+    await ops_test.model.wait_for_idle(
+        status="active",
+        raise_on_blocked=False,
+        timeout=90 * 10,
+    )
+
+    # Wait for the pods from our secondary workload, just in case.  This should be faster than
+    # the charms but maybe not.
+    await ops_test.run(
+        'kubectl',
+        'wait',
+        '--for=condition=ready',
+        'pod',
+        '--all',
+        f'-n={namespace}',
+        '--timeout=5m',
+        check=True,
+    )
+
+    # Test that traffic over the restricted port (8080, the regular ingress) is redirected to dex
+    assert_url_get(f'http://{regular_ingress_gateway_ip}/productpage', allowed_statuses=[302], disallowed_statuses=[200])
+
+    # Test that traffic over the secondary port (8081) is not redirected to dex
+    secondary_gateway_ip = await get_gateway_ip(ops_test, f"{test_workload_name}-loadbalancer")
+    assert_url_get(f'http://{secondary_gateway_ip}/test', allowed_statuses=[200], disallowed_statuses=[302])
+
+
+def deploy_workload_with_gateway(workload_name: str, gateway_port: int, namespace: str):
+    """Deploys an http server and opens a path through the existing istio proxy."""
+    client = lightkube.Client()
+    load_in_cluster_generic_resources(client)
+
+    context = {
+        "workload_name": workload_name,
+        "namespace": namespace,
+        "gateway_port": gateway_port,
+    }
+    manifest = codecs.load_all_yaml(
+        Path("./tests/test_ingress_auth_manifest_for_setup.yaml.j2").read_text(), context=context
+    )
+
+    for r in manifest:
+        client.create(r, r.metadata.name)
+
+
 # TODO: Change this to use lightkube
-def get_gateway_ip(ops_test: OpsTest):
+async def get_gateway_ip(ops_test: OpsTest, service_name: str = "istio-ingressgateway-workload"):
     gateway_json = await ops_test.run(
         'kubectl',
         'get',
-        'services/istio-ingressgateway-workload',
+        f'services/{service_name}',
         '-n',
         ops_test.model_name,
         '-ojson',
@@ -130,3 +260,26 @@ def get_gateway_ip(ops_test: OpsTest):
 
     gateway_obj = json.loads(gateway_json[1])
     return gateway_obj['status']['loadBalancer']['ingress'][0]['ip']
+
+
+def assert_url_get(url, allowed_statuses: list, disallowed_statuses: list):
+    """Asserts that we receive one of a list of allowed status when we `get` an url, or raises.
+
+    Raises after max number of attempts or if you receive a disallowed status code
+    """
+    i = 0
+    max_attempts = 20
+    while i < max_attempts:
+        # Test that traffic over the restricted port (8080, the regular ingress) is redirected to dex
+        r = requests.get(url, allow_redirects=False)
+        if r.status_code in allowed_statuses:
+            return
+        elif r.status_code in disallowed_statuses:
+            raise ValueError(
+                f"Got disallowed status code {r.status_code}.  Communication not as expected"
+            )
+        sleep(5)
+
+    raise ValueError(
+        "Timed out before getting an allowed status code.  Communication not as expected"
+    )

--- a/tests/test_ingress_auth_manifest_for_setup.yaml.j2
+++ b/tests/test_ingress_auth_manifest_for_setup.yaml.j2
@@ -1,0 +1,95 @@
+# Creates istio gateway, virtualService, and Service to support access to the Bookinfo application through
+# a second port.  This simulates traffic like seen in knative or elsewhere that adds its own gateway port alongside
+# the kubeflow setup, so we can confirm we have only applied auth restrictions to some ports on our gateway
+
+# LoadBalancer for ingress of external communication into cluster
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ workload_name }}-loadbalancer
+  namespace: {{ namespace }}
+spec:
+  ports:
+    - name: http2
+      port: 80
+      protocol: TCP
+      targetPort: {{ gateway_port }}
+  selector:
+    istio: ingressgateway
+  type: 'LoadBalancer'
+---
+# Gateway for ingress
+apiVersion: networking.istio.io/v1beta1
+kind: Gateway
+metadata:
+  name: {{ workload_name }}
+  namespace: {{ namespace }}
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - hosts:
+    - '*'
+    port:
+      name: http
+      number: {{ gateway_port }}
+      protocol: HTTP
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: {{ workload_name }}
+  namespace: {{ namespace }}
+spec:
+  gateways:
+  - {{ namespace }}/{{ workload_name }}
+  hosts:
+  - '*'
+  http:
+  - match:
+    - uri:
+        exact: /test
+    route:
+    - destination:
+        host: {{ workload_name }}
+        port:
+          number: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ workload_name }}
+  namespace: {{ namespace }}
+  labels:
+    app: {{ workload_name }}
+spec:
+  ports:
+    - port: 80
+      targetPort: 8080
+      name: html
+  selector:
+    app: {{ workload_name }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ workload_name }}
+  namespace: {{ namespace }}
+  labels:
+    app: {{ workload_name }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ workload_name }}
+  template:
+    metadata:
+      labels:
+        app: {{ workload_name }}
+    spec:
+      containers:
+      - name: workload
+        image: ksonny4/simple-docker-http-server
+        ports:
+        - containerPort: 8080
+          name: html
+---


### PR DESCRIPTION
This change restricts the `EnvoyFilter` created by the `ingress-auth` relation to apply only to the port (8080) which is used for Kubeflow's ingress traffic through the ingress gateway.  This is to address problems like seen in canonical/knative-operators#51, where our previous configuration accidentally forwarded in-cluster traffic to dex.

### Test instructions

* clone this repo
* `KUBECONFIG=[path-to-your-kubeconfig] tox -e integration

Fixes canonical/knative-operators#51