### PR TITLE
Fix: Retrieval of gateway address from Service.

### DIFF
--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -326,7 +326,17 @@ class Operator(CharmBase):
         svcs = self.lightkube_client.get(
             Service, name="istio-ingressgateway-workload", namespace=self.model.name
         )
-        return svcs.status.loadBalancer.ingress[0].ip
+
+        # return gateway address: hostname or IP; None if not set
+        gateway_address = None
+        if hasattr(svcs.status.loadBalancer.ingress[0], 'hostname') and \
+                svcs.status.loadBalancer.ingress[0].hostname != None:
+            gateway_address = svcs.status.loadBalancer.ingress[0].hostname
+        elif hasattr(svcs.status.loadBalancer.ingress[0], 'ip') and \
+                svcs.status.loadBalancer.ingress[0].ip != None:
+            gateway_address = svcs.status.loadBalancer.ingress[0].ip
+
+        return gateway_address
 
 
 if __name__ == "__main__":

--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -329,11 +329,15 @@ class Operator(CharmBase):
 
         # return gateway address: hostname or IP; None if not set
         gateway_address = None
-        if hasattr(svcs.status.loadBalancer.ingress[0], 'hostname') and \
-                svcs.status.loadBalancer.ingress[0].hostname != None:
+        if (
+            hasattr(svcs.status.loadBalancer.ingress[0], 'hostname')
+            and svcs.status.loadBalancer.ingress[0].hostname is not None
+        ):
             gateway_address = svcs.status.loadBalancer.ingress[0].hostname
-        elif hasattr(svcs.status.loadBalancer.ingress[0], 'ip') and \
-                svcs.status.loadBalancer.ingress[0].ip != None:
+        elif (
+            hasattr(svcs.status.loadBalancer.ingress[0], 'ip')
+            and svcs.status.loadBalancer.ingress[0].ip is not None
+        ):
             gateway_address = svcs.status.loadBalancer.ingress[0].ip
 
         return gateway_address

--- a/charms/istio-pilot/tests/unit/test_charm.py
+++ b/charms/istio-pilot/tests/unit/test_charm.py
@@ -477,6 +477,7 @@ def test_remove_exceptions(harness, mocked_client, mocker):
     with pytest.raises(ApiError):
         harness.charm.on.remove.emit()
 
+
 #
 # Test Service
 #
@@ -486,6 +487,7 @@ def test_remove_exceptions(harness, mocked_client, mocker):
 def mocked_get(mocked_charm_client, mocker):
     return
 
+
 def test_service(harness, subprocess, mocked_client, helpers, mocker, mocked_list):
 
     mocker.patch('resources_handler.load_in_cluster_generic_resources')
@@ -494,40 +496,34 @@ def test_service(harness, subprocess, mocked_client, helpers, mocker, mocked_lis
 
     # Test retrieval of gateway address set in Service
     # verify None
-    harness.charm.lightkube_client.get.return_value = codecs.from_dict({
+    harness.charm.lightkube_client.get.return_value = codecs.from_dict(
+        {
             'apiVersion': 'v1',
             'kind': 'Service',
-            'status': {
-                'loadBalancer': {
-                    'ingress': [ { } ]
-                }
-            },
-        })
-    assert harness.charm._gateway_address == None
+            'status': {'loadBalancer': {'ingress': [{}]}},
+        }
+    )
+    assert harness.charm._gateway_address is None
     harness.charm.lightkube_client.get.return_value = None
 
     # verify IP address
-    harness.charm.lightkube_client.get.return_value = codecs.from_dict({
+    harness.charm.lightkube_client.get.return_value = codecs.from_dict(
+        {
             'apiVersion': 'v1',
             'kind': 'Service',
-            'status': {
-                'loadBalancer': {
-                    'ingress': [ { 'ip' : "127.0.0.1" } ]
-                }
-            },
-        })
+            'status': {'loadBalancer': {'ingress': [{'ip': "127.0.0.1"}]}},
+        }
+    )
     assert harness.charm._gateway_address == "127.0.0.1"
     harness.charm.lightkube_client.get.return_value = None
 
     # verify hostname
-    harness.charm.lightkube_client.get.return_value = codecs.from_dict({
+    harness.charm.lightkube_client.get.return_value = codecs.from_dict(
+        {
             'apiVersion': 'v1',
             'kind': 'Service',
-            'status': {
-                'loadBalancer': {
-                    'ingress': [ { 'hostname' : "test.com" } ]
-                }
-            },
-        })
+            'status': {'loadBalancer': {'ingress': [{'hostname': "test.com"}]}},
+        }
+    )
     assert harness.charm._gateway_address == "test.com"
     harness.charm.lightkube_client.get.return_value = None

--- a/charms/istio-pilot/tests/unit/test_charm.py
+++ b/charms/istio-pilot/tests/unit/test_charm.py
@@ -476,3 +476,58 @@ def test_remove_exceptions(harness, mocked_client, mocker):
     mocked_client.return_value.delete.side_effect = api_error
     with pytest.raises(ApiError):
         harness.charm.on.remove.emit()
+
+#
+# Test Service
+#
+# Overriding mocked_get(autouse=True) fixture (disabling autouse) to allow setting
+# of return value of get() method.
+@pytest.fixture(scope="function")
+def mocked_get(mocked_charm_client, mocker):
+    return
+
+def test_service(harness, subprocess, mocked_client, helpers, mocker, mocked_list):
+
+    mocker.patch('resources_handler.load_in_cluster_generic_resources')
+    harness.set_leader(True)
+    harness.begin()
+
+    # Test retrieval of gateway address set in Service
+    # verify None
+    harness.charm.lightkube_client.get.return_value = codecs.from_dict({
+            'apiVersion': 'v1',
+            'kind': 'Service',
+            'status': {
+                'loadBalancer': {
+                    'ingress': [ { } ]
+                }
+            },
+        })
+    assert harness.charm._gateway_address == None
+    harness.charm.lightkube_client.get.return_value = None
+
+    # verify IP address
+    harness.charm.lightkube_client.get.return_value = codecs.from_dict({
+            'apiVersion': 'v1',
+            'kind': 'Service',
+            'status': {
+                'loadBalancer': {
+                    'ingress': [ { 'ip' : "127.0.0.1" } ]
+                }
+            },
+        })
+    assert harness.charm._gateway_address == "127.0.0.1"
+    harness.charm.lightkube_client.get.return_value = None
+
+    # verify hostname
+    harness.charm.lightkube_client.get.return_value = codecs.from_dict({
+            'apiVersion': 'v1',
+            'kind': 'Service',
+            'status': {
+                'loadBalancer': {
+                    'ingress': [ { 'hostname' : "test.com" } ]
+                }
+            },
+        })
+    assert harness.charm._gateway_address == "test.com"
+    harness.charm.lightkube_client.get.return_value = None


### PR DESCRIPTION
**PR for fix of retrieval of gateway address from Service.**
Work tracked in https://github.com/canonical/istio-operators/issues/117

Summary of changes:
- Modified code to properly parse Service resource and return either IP or hostname as gateway address.
- Added unit tests (with disabling of autouse fixture).

**Outcomes**
`istio-pilot` pod should not produce error log when load balancer with hostname instead of IP address is used. It should successfully retrieve hostname.

**Testing**
Will be updated once finilized.
