### PR TITLE
Added ingress service type variable (ClusterIP or Loadbalancer)

### DIFF
--- a/charms/istio-gateway/config.yaml
+++ b/charms/istio-gateway/config.yaml
@@ -3,3 +3,8 @@ options:
     default: ''
     description: Kind of Istio gateway. Must be set to one of `ingress`, `egress`
     type: string
+  gateway_service_type:
+    default: 'LoadBalancer'
+    type: string
+    description: |
+      Type of service for the ingress gateway out of: 'ClusterIP' or 'LoadBalancer'.

--- a/charms/istio-gateway/src/charm.py
+++ b/charms/istio-gateway/src/charm.py
@@ -54,6 +54,12 @@ class Operator(CharmBase):
             event.defer()
             return
 
+        if self.model.config["gateway_service_type"] not in ("LoadBalancer", "ClusterIP"):
+            self.model.unit.status = BlockedStatus(
+                "Ingress GW svc must be of type: LoadBalancer, ClusterIP"
+            )
+            return
+
         pilot = list(pilot.get_data().values())[0]
 
         env = Environment(loader=FileSystemLoader('src'))
@@ -63,6 +69,7 @@ class Operator(CharmBase):
             namespace=self.model.name,
             pilot_host=pilot['service-name'],
             pilot_port=pilot['service-port'],
+            gateway_service_type=self.model.config["gateway_service_type"],
         )
 
         for obj in codecs.load_all_yaml(rendered):

--- a/charms/istio-gateway/src/manifest.yaml
+++ b/charms/istio-gateway/src/manifest.yaml
@@ -318,4 +318,4 @@ spec:
       targetPort: 8443
   selector:
     istio: {{ kind }}gateway
-  type: {{ 'ClusterIP' if kind == 'egress' else 'LoadBalancer' }}
+  type: {{ 'ClusterIP' if kind == 'egress' else gateway_service_type }}

--- a/charms/istio-gateway/tests/unit/conftest.py
+++ b/charms/istio-gateway/tests/unit/conftest.py
@@ -41,3 +41,28 @@ def configured_harness(harness, kind):
     harness.begin_with_initial_hooks()
 
     return harness
+
+
+@pytest.fixture(params=["LoadBalancer", "ClusterIP"])
+def gateway_service_type(request):
+    return request.param
+
+
+@pytest.fixture()
+def configured_harness_only_ingress(harness, gateway_service_type):
+    harness.set_leader(True)
+
+    harness.update_config({'kind': 'ingress', 'gateway_service_type': gateway_service_type})
+    rel_id = harness.add_relation("istio-pilot", "app")
+
+    harness.add_relation_unit(rel_id, "app/0")
+    data = {"service-name": "service-name", "service-port": '6666'}
+    harness.update_relation_data(
+        rel_id,
+        "app",
+        {"_supported_versions": "- v1", "data": yaml.dump(data)},
+    )
+
+    harness.begin_with_initial_hooks()
+
+    return harness

--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -341,7 +341,10 @@ class Operator(CharmBase):
 
         # return gateway address: hostname or IP; None if not set
         gateway_address = None
-        if (
+
+        if svcs.spec.type == 'ClusterIP':
+            gateway_address = svcs.spec.clusterIP
+        elif (
             hasattr(svcs.status.loadBalancer.ingress[0], 'hostname')
             and svcs.status.loadBalancer.ingress[0].hostname is not None
         ):


### PR DESCRIPTION
This is PR based on: 
- https://github.com/canonical/istio-operators/pull/67
- https://github.com/canonical/istio-operators/pull/129

This PR allows exposing applications behind the Istio gateway via Ingress Controller & rule