### PR TITLE
feat: add alert rules for istio-pilot

### DIFF
--- a/charms/istio-pilot/src/prometheus_alert_rules/istio.rule
+++ b/charms/istio-pilot/src/prometheus_alert_rules/istio.rule
@@ -1,0 +1,7 @@
+alert: IstioPilotAvailabilityDrop
+annotations:
+  summary: 'Istio Pilot Availability Drop'
+  description: 'Pilot pods have dropped during the last 5m (current value: *{{ printf "%2.0f%%" $value }}*). Envoy sidecars might have outdated configuration'
+expr: >
+  avg(avg_over_time(up[1m])) < 0.5
+for: 5m


### PR DESCRIPTION
Adds alert rules and corresponding unit/integration tests.

Dear reviewers, this PR depends on #132, and thus should be merged after rebasing on top of a HEAD with the change from that other PR.