### PR TITLE
backport config option to enable ClusterIP usage

### DIFF
--- a/charms/istio-gateway/config.yaml
+++ b/charms/istio-gateway/config.yaml
@@ -5,6 +5,7 @@ options:
     type: string
   ingress_service_type:
     default: 'LoadBalancer'
+    type: string
     description: |
       Type of service for the ingress gateway out of: 'ClusterIP' or 'LoadBalancer'. 
       Egress gateways are always set as ClusterIP

--- a/charms/istio-gateway/config.yaml
+++ b/charms/istio-gateway/config.yaml
@@ -3,3 +3,8 @@ options:
     default: ''
     description: Kind of Istio gateway. Must be set to one of `ingress`, `egress`
     type: string
+  ingress_service_type:
+    default: 'LoadBalancer'
+    description: |
+      Type of service for the ingress gateway out of: 'ClusterIP' or 'LoadBalancer'. 
+      Egress gateways are always set as ClusterIP

--- a/charms/istio-gateway/config.yaml
+++ b/charms/istio-gateway/config.yaml
@@ -3,9 +3,8 @@ options:
     default: ''
     description: Kind of Istio gateway. Must be set to one of `ingress`, `egress`
     type: string
-  ingress_service_type:
+  gateway_service_type:
     default: 'LoadBalancer'
     type: string
     description: |
-      Type of service for the ingress gateway out of: 'ClusterIP' or 'LoadBalancer'. 
-      Egress gateways are always set as ClusterIP
+      Type of service for the ingress gateway out of: 'ClusterIP' or 'LoadBalancer'.

--- a/charms/istio-gateway/src/charm.py
+++ b/charms/istio-gateway/src/charm.py
@@ -54,6 +54,12 @@ class Operator(CharmBase):
             event.defer()
             return
 
+        if self.model.config["ingress_service_type"] not in ("LoadBalancer", "ClusterIP"):
+            self.model.unit.status = BlockedStatus(
+                "Ingress GW svc must be of type: LoadBalancer, ClusterIP"
+            )
+            return
+
         pilot = list(pilot.get_data().values())[0]
 
         env = Environment(loader=FileSystemLoader('src'))
@@ -63,6 +69,7 @@ class Operator(CharmBase):
             namespace=self.model.name,
             pilot_host=pilot['service-name'],
             pilot_port=pilot['service-port'],
+            ingress_service_type=self.model.config["ingress_service_type"],
         )
 
         for obj in codecs.load_all_yaml(rendered):

--- a/charms/istio-gateway/src/charm.py
+++ b/charms/istio-gateway/src/charm.py
@@ -54,7 +54,7 @@ class Operator(CharmBase):
             event.defer()
             return
 
-        if self.model.config["ingress_service_type"] not in ("LoadBalancer", "ClusterIP"):
+        if self.model.config["gateway_service_type"] not in ("LoadBalancer", "ClusterIP"):
             self.model.unit.status = BlockedStatus(
                 "Ingress GW svc must be of type: LoadBalancer, ClusterIP"
             )
@@ -69,7 +69,7 @@ class Operator(CharmBase):
             namespace=self.model.name,
             pilot_host=pilot['service-name'],
             pilot_port=pilot['service-port'],
-            ingress_service_type=self.model.config["ingress_service_type"],
+            gateway_service_type=self.model.config["gateway_service_type"],
         )
 
         for obj in codecs.load_all_yaml(rendered):

--- a/charms/istio-gateway/src/manifest.yaml
+++ b/charms/istio-gateway/src/manifest.yaml
@@ -318,4 +318,4 @@ spec:
       targetPort: 8443
   selector:
     istio: {{ kind }}gateway
-  type: {{ 'ClusterIP' if kind == 'egress' else 'LoadBalancer' }}
+  type: {{ 'ClusterIP' if kind == 'egress' else ingress_service_type }}

--- a/charms/istio-gateway/src/manifest.yaml
+++ b/charms/istio-gateway/src/manifest.yaml
@@ -318,4 +318,4 @@ spec:
       targetPort: 8443
   selector:
     istio: {{ kind }}gateway
-  type: {{ 'ClusterIP' if kind == 'egress' else ingress_service_type }}
+  type: {{ 'ClusterIP' if kind == 'egress' else gateway_service_type }}

--- a/charms/istio-gateway/tests/unit/conftest.py
+++ b/charms/istio-gateway/tests/unit/conftest.py
@@ -44,15 +44,15 @@ def configured_harness(harness, kind):
 
 
 @pytest.fixture(params=["LoadBalancer", "ClusterIP"])
-def ingress_service_type(request):
+def gateway_service_type(request):
     return request.param
 
 
 @pytest.fixture()
-def configured_harness_only_ingress(harness, ingress_service_type):
+def configured_harness_only_ingress(harness, gateway_service_type):
     harness.set_leader(True)
 
-    harness.update_config({'kind': 'ingress', 'ingress_service_type': ingress_service_type})
+    harness.update_config({'kind': 'ingress', 'gateway_service_type': gateway_service_type})
     rel_id = harness.add_relation("istio-pilot", "app")
 
     harness.add_relation_unit(rel_id, "app/0")

--- a/charms/istio-gateway/tests/unit/test_charm.py
+++ b/charms/istio-gateway/tests/unit/test_charm.py
@@ -111,3 +111,30 @@ def test_removal(configured_harness, kind, mocked_client, mocker):
     mocked_client.return_value.delete.side_effect = api_error
     with pytest.raises(ApiError):
         configured_harness.charm.on.remove.emit()
+
+
+def test_service_type_cluserip(
+    configured_harness_only_ingress, ingress_service_type, mocked_client
+):
+    # Reset the mock so that the calls list does not include any calls from other hooks
+    mocked_client.reset_mock()
+
+    configured_harness_only_ingress.charm.on.start.emit()
+    actual_objects = []
+
+    # the apply method is called for every object in the manifest
+    for call in mocked_client.return_value.apply.call_args_list:
+        # Ensure the server side apply calls include the namespace kwarg
+        assert call.kwargs['namespace'] == 'None'
+        # The first (and only) argument to the apply method is the obj
+        # Convert the object to a dictionary and add it to the list
+        actual_objects.append(call.args[0].to_dict())
+
+    services = filter(lambda obj: obj.get('kind') == 'Service', actual_objects)
+    ingress_workloads = filter(
+        lambda obj: obj['metadata'].get('name') == "istio-ingressgateway-workload", services
+    )
+    workload_service = list(ingress_workloads)[0]
+
+    assert workload_service['spec'].get('type') == ingress_service_type
+    assert configured_harness_only_ingress.charm.model.unit.status == ActiveStatus('')

--- a/charms/istio-gateway/tests/unit/test_charm.py
+++ b/charms/istio-gateway/tests/unit/test_charm.py
@@ -114,7 +114,7 @@ def test_removal(configured_harness, kind, mocked_client, mocker):
 
 
 def test_service_type_cluserip(
-    configured_harness_only_ingress, ingress_service_type, mocked_client
+    configured_harness_only_ingress, gateway_service_type, mocked_client
 ):
     # Reset the mock so that the calls list does not include any calls from other hooks
     mocked_client.reset_mock()
@@ -136,5 +136,5 @@ def test_service_type_cluserip(
     )
     workload_service = list(ingress_workloads)[0]
 
-    assert workload_service['spec'].get('type') == ingress_service_type
+    assert workload_service['spec'].get('type') == gateway_service_type
     assert configured_harness_only_ingress.charm.model.unit.status == ActiveStatus('')

--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -326,7 +326,24 @@ class Operator(CharmBase):
         svcs = self.lightkube_client.get(
             Service, name="istio-ingressgateway-workload", namespace=self.model.name
         )
-        return svcs.status.loadBalancer.ingress[0].ip
+
+        # return gateway address: hostname or IP; None if not set
+        gateway_address = None
+
+        if svcs.spec.type == 'ClusterIP':
+            gateway_address = svcs.spec.clusterIP
+        elif (
+            hasattr(svcs.status.loadBalancer.ingress[0], 'hostname')
+            and svcs.status.loadBalancer.ingress[0].hostname is not None
+        ):
+            gateway_address = svcs.status.loadBalancer.ingress[0].hostname
+        elif (
+            hasattr(svcs.status.loadBalancer.ingress[0], 'ip')
+            and svcs.status.loadBalancer.ingress[0].ip is not None
+        ):
+            gateway_address = svcs.status.loadBalancer.ingress[0].ip
+
+        return gateway_address
 
 
 if __name__ == "__main__":

--- a/charms/istio-pilot/tests/unit/test_charm.py
+++ b/charms/istio-pilot/tests/unit/test_charm.py
@@ -476,3 +476,72 @@ def test_remove_exceptions(harness, mocked_client, mocker):
     mocked_client.return_value.delete.side_effect = api_error
     with pytest.raises(ApiError):
         harness.charm.on.remove.emit()
+
+
+def test_loadbalancer_service(harness, subprocess, mocked_client, helpers, mocker, mocked_list):
+    """Test that the charm._gateway_address correctly returns gateway service IP/hostname."""
+
+    mocker.patch('resources_handler.load_in_cluster_generic_resources')
+    harness.set_leader(True)
+    harness.begin()
+
+    # Test retrieval of gateway address set in Service
+    # verify None
+    harness.charm.lightkube_client.get.side_effect = [
+        codecs.from_dict(
+            {
+                'apiVersion': 'v1',
+                'kind': 'Service',
+                'status': {'loadBalancer': {'ingress': [{}]}},
+                'spec': {'type': 'LoadBalancer', 'clusterIP': '10.10.10.10'},
+            }
+        )
+    ]
+    assert harness.charm._gateway_address is None
+
+    # verify IP address
+    harness.charm.lightkube_client.get.side_effect = [
+        codecs.from_dict(
+            {
+                'apiVersion': 'v1',
+                'kind': 'Service',
+                'status': {'loadBalancer': {'ingress': [{'ip': "127.0.0.1"}]}},
+                'spec': {'type': 'LoadBalancer', 'clusterIP': '10.10.10.10'},
+            }
+        )
+    ]
+    assert harness.charm._gateway_address == "127.0.0.1"
+
+    # verify hostname
+    harness.charm.lightkube_client.get.side_effect = [
+        codecs.from_dict(
+            {
+                'apiVersion': 'v1',
+                'kind': 'Service',
+                'status': {'loadBalancer': {'ingress': [{'hostname': "test.com"}]}},
+                'spec': {'type': 'LoadBalancer', 'clusterIP': '10.10.10.10'},
+            }
+        )
+    ]
+    assert harness.charm._gateway_address == "test.com"
+
+
+def test_clusterip_service(harness, subprocess, mocked_client, helpers, mocker, mocked_list):
+    """Test that the charm._gateway_address correctly returns gateway service IP/hostname."""
+
+    mocker.patch('resources_handler.load_in_cluster_generic_resources')
+    harness.set_leader(True)
+    harness.begin()
+
+    # Test retrieval of gateway address set in Service
+    harness.charm.lightkube_client.get.side_effect = [
+        codecs.from_dict(
+            {
+                'apiVersion': 'v1',
+                'kind': 'Service',
+                'status': {'loadBalancer': {}},
+                'spec': {'type': 'ClusterIP', 'clusterIP': '10.10.10.10'},
+            }
+        )
+    ]
+    assert harness.charm._gateway_address == '10.10.10.10'


### PR DESCRIPTION
This is a backport from main to track/1.11 of the following:

* [Added change to istio-pilot to change ingress workload as ClusterIP](https://github.com/canonical/istio-operators/commit/7943735b67a56df05ae58d1d3c162b94347ab5fa)
* [code review comments applied.](https://github.com/canonical/istio-operators/commit/afb2a50c4a917b8dc758248505478eed12f6a840)
* [missing type key added](https://github.com/canonical/istio-operators/commit/9947502f59ae700940db9335aaa38a70edcdeb19)
* [Added ingress service type variable with options ClusterIP and Loadba…](https://github.com/canonical/istio-operators/commit/9c11f131ef110080569ebcb6c6120ccb4924c78e)