### PR TITLE
feat: istioctl version bump 1.11->1.16

### DIFF
--- a/charms/istio-pilot/charmcraft.yaml
+++ b/charms/istio-pilot/charmcraft.yaml
@@ -13,5 +13,5 @@ parts:
     build-packages: [git]
   istioctl:
     plugin: dump
-    source: https://github.com/istio/istio/releases/download/1.11.0/istioctl-1.11.0-linux-amd64.tar.gz
+    source: https://github.com/istio/istio/releases/download/1.16.2/istioctl-1.16.2-linux-amd64.tar.gz
     source-type: tar


### PR DESCRIPTION
Bump the version of the binary we use in istio-pilot.

#### Relevant manual testing:

* juju deploy local build goes active and idle
* deploy local build of `istio-pilot` alongside the [Charmed Kubeflow 1.6 bundle](https://github.com/canonical/bundle-kubeflow/blob/main/releases/1.6/stable/kubeflow/bundle.yaml), all charms that relate to istio-pilot are active and idle
* after proper configuration, the Kubeflow Dashboard (from provided by the bundle ^) can be accessed