### PR TITLE
feat: localize SDI schemas

### DIFF
--- a/charms/istio-gateway/metadata.yaml
+++ b/charms/istio-gateway/metadata.yaml
@@ -7,7 +7,19 @@ description: |
 requires:
   istio-pilot:
     interface: k8s-service
-    schema: https://raw.githubusercontent.com/canonical/operator-schemas/master/k8s-service.yaml
+    schema:
+      v1:
+        provides:
+          type: object
+          properties:
+            service-name:
+              type: string
+            service-port:
+              type: string
+          required:
+          - service-name
+          - service-port
     versions: [v1]
+    __schema_source: https://raw.githubusercontent.com/canonical/operator-schemas/master/k8s-service.yaml
 assumes:
-  - juju >= 2.9.0
+- juju >= 2.9.0

--- a/charms/istio-pilot/metadata.yaml
+++ b/charms/istio-pilot/metadata.yaml
@@ -11,19 +11,87 @@ provides:
     interface: grafana_dashboard
   istio-pilot:
     interface: k8s-service
-    schema: https://raw.githubusercontent.com/canonical/operator-schemas/master/k8s-service.yaml
+    schema:
+      v1:
+        provides:
+          type: object
+          properties:
+            service-name:
+              type: string
+            service-port:
+              type: string
+          required:
+          - service-name
+          - service-port
     versions: [v1]
+    __schema_source: https://raw.githubusercontent.com/canonical/operator-schemas/master/k8s-service.yaml
   ingress:
     interface: ingress
-    schema: https://raw.githubusercontent.com/canonical/operator-schemas/master/ingress.yaml
+    schema:
+      v2:
+        requires:
+          type: object
+          properties:
+            service:
+              type: string
+            port:
+              type: integer
+            namespace:
+              type: string
+            prefix:
+              type: string
+            rewrite:
+              type: string
+          required:
+          - service
+          - port
+          - namespace
+          - prefix
+      v1:
+        requires:
+          type: object
+          properties:
+            service:
+              type: string
+            port:
+              type: integer
+            prefix:
+              type: string
+            rewrite:
+              type: string
+          required:
+          - service
+          - port
+          - prefix
     versions: [v1, v2]
+    __schema_source: https://raw.githubusercontent.com/canonical/operator-schemas/master/ingress.yaml
   ingress-auth:
     interface: ingress-auth
-    schema: https://raw.githubusercontent.com/canonical/operator-schemas/master/ingress-auth.yaml
+    schema:
+      v1:
+        requires:
+          type: object
+          properties:
+            service:
+              type: string
+            port:
+              type: integer
+            allowed-request-headers:
+              type: array
+              items:
+                type: string
+            allowed-response-headers:
+              type: array
+              items:
+                type: string
+          required:
+          - service
+          - port
     versions: [v1]
+    __schema_source: https://raw.githubusercontent.com/canonical/operator-schemas/master/ingress-auth.yaml
   gateway-info:
     interface: istio-gateway-info
     description: |
       Provides gateway name related Juju application
 assumes:
-  - juju >= 2.9.0
+- juju >= 2.9.0


### PR DESCRIPTION
This vendors all remotely defined serialized-data-interface schemas, embedding them in the respective metadata.yaml(s) rather than storing them as a remote link.  This is to enable offline deployment of the charms, as described in [jira](https://warthogs.atlassian.net/browse/KF-727?atlOrigin=eyJpIjoiN2JjZTdlMGYxNDQ3NDdlYzljZDQxNDQ1MTk0OTdkNTEiLCJwIjoiaiJ9).