### PR TITLE
ci: multiple fixes for track/1.11 CI

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -81,7 +81,7 @@ jobs:
 
     - name: Bootstrap
       run: |
-        sg microk8s -c 'juju bootstrap microk8s uk8s'
+        sg microk8s -c 'juju bootstrap microk8s uk8s --agent-version=2.9.34'
         sg microk8s -c 'juju add-model istio-system'
 
     - run: sg microk8s -c 'KUBECONFIG=/home/runner/.kube/config tox -e integration

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -11,7 +11,7 @@ jobs:
 
   lib-check:
     name: Check libraries
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         charm:
@@ -30,7 +30,7 @@ jobs:
         github-token: "${{ secrets.GITHUB_TOKEN }}"
   lint:
     name: Lint Code
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         charm: [pilot, gateway]
@@ -41,7 +41,7 @@ jobs:
 
   unit:
     name: Unit Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         charm: [pilot, gateway]
@@ -52,7 +52,7 @@ jobs:
 
   integration:
     name: Integration Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - name: Check out repo

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -60,7 +60,8 @@ jobs:
 
     - uses: balchua/microk8s-actions@v0.2.2
       with:
-        channel: 'latest/stable'
+        # Pin microk8s 1.24 as istio 1.11 is not compatible with greater versions
+        channel: '1.24/stable'
         addons: '["dns", "storage", "rbac", "metallb:10.64.140.43-10.64.140.49"]'
 
     - name: Install dependencies

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -28,7 +28,7 @@ on:
 jobs:
   get-charm-paths:
     name: Generate the Charm Matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       charm_paths_list: ${{ steps.get-charm-paths.outputs.CHARM_PATHS_LIST }}
     steps:
@@ -43,7 +43,7 @@ jobs:
 
   publish-charm:
     name: Publish Charm
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: get-charm-paths
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ on:
 jobs:
   promote-charm:
     name: Promote charm
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Release charm to channel

--- a/charms/istio-gateway/requirements.txt
+++ b/charms/istio-gateway/requirements.txt
@@ -2,5 +2,6 @@ jinja2<3.1
 ops<1.4.0
 requests<2.27.0
 serialized-data-interface<0.4
-lightkube>=0.10.1
+lightkube==0.10.1
+lightkube-models==1.22.0.4
 oci-image


### PR DESCRIPTION
This PR introduces the following:

* ci: pin ubuntu 20.04 in integrate, publish, and release jobs
Pinning the version avoids incompatibilities with building the charm and installing certain dependencies.
* build: pin lightkube and lightkube-models to versions that are compatible with the charm and test code
* bootstrap juju with agent 2.9.34 to avoid https://bugs.launchpad.net/juju/+bug/1992833