### PR TITLE
feat: add option to use `NodePort` for istio-gateway

### DIFF
--- a/charms/istio-gateway/config.yaml
+++ b/charms/istio-gateway/config.yaml
@@ -7,4 +7,4 @@ options:
     default: 'LoadBalancer'
     type: string
     description: |
-      Type of service for the ingress gateway out of: 'ClusterIP' or 'LoadBalancer'.
+      Type of service for the ingress gateway out of: 'ClusterIP', 'LoadBalancer', or "NodePort".

--- a/charms/istio-gateway/src/charm.py
+++ b/charms/istio-gateway/src/charm.py
@@ -10,7 +10,6 @@ from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, StatusBase, WaitingStatus
 from serialized_data_interface import NoCompatibleVersions, NoVersionsListed, get_interfaces
 
-
 SUPPORTED_GATEWAY_SERVICE_TYPES = ["LoadBalancer", "ClusterIP", "NodePort"]
 
 

--- a/charms/istio-gateway/src/charm.py
+++ b/charms/istio-gateway/src/charm.py
@@ -11,6 +11,9 @@ from ops.model import ActiveStatus, BlockedStatus, StatusBase, WaitingStatus
 from serialized_data_interface import NoCompatibleVersions, NoVersionsListed, get_interfaces
 
 
+SUPPORTED_GATEWAY_SERVICE_TYPES = ["LoadBalancer", "ClusterIP", "NodePort"]
+
+
 class Operator(CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
@@ -54,9 +57,9 @@ class Operator(CharmBase):
             event.defer()
             return
 
-        if self.model.config["gateway_service_type"] not in ("LoadBalancer", "ClusterIP"):
+        if self.model.config["gateway_service_type"] not in SUPPORTED_GATEWAY_SERVICE_TYPES:
             self.model.unit.status = BlockedStatus(
-                "Ingress GW svc must be of type: LoadBalancer, ClusterIP"
+                f"Ingress Gateway Service must one of type: {SUPPORTED_GATEWAY_SERVICE_TYPES}"
             )
             return
 

--- a/charms/istio-gateway/tests/unit/conftest.py
+++ b/charms/istio-gateway/tests/unit/conftest.py
@@ -44,7 +44,7 @@ def configured_harness(harness, kind):
     return harness
 
 
-@pytest.fixture(params=["LoadBalancer", "ClusterIP"])
+@pytest.fixture(params=["LoadBalancer", "ClusterIP", "NodePort"])
 def gateway_service_type(request):
     return request.param
 

--- a/charms/istio-gateway/tests/unit/test_charm.py
+++ b/charms/istio-gateway/tests/unit/test_charm.py
@@ -113,7 +113,7 @@ def test_removal(configured_harness, kind, mocked_client, mocker):
         configured_harness.charm.on.remove.emit()
 
 
-def test_service_type_cluserip(
+def test_service_type(
     configured_harness_only_ingress, gateway_service_type, mocked_client
 ):
     # Reset the mock so that the calls list does not include any calls from other hooks

--- a/charms/istio-gateway/tests/unit/test_charm.py
+++ b/charms/istio-gateway/tests/unit/test_charm.py
@@ -113,9 +113,7 @@ def test_removal(configured_harness, kind, mocked_client, mocker):
         configured_harness.charm.on.remove.emit()
 
 
-def test_service_type(
-    configured_harness_only_ingress, gateway_service_type, mocked_client
-):
+def test_service_type(configured_harness_only_ingress, gateway_service_type, mocked_client):
     # Reset the mock so that the calls list does not include any calls from other hooks
     mocked_client.reset_mock()
 

--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -367,6 +367,7 @@ class Operator(CharmBase):
                 return False
 
     def _get_gateway_service(self):
+        """Returns a lightkube Service object for the gateway service."""
         # FIXME: service name is hardcoded and depends on the istio gateway application name being
         #  `istio-ingressgateway`.  This is very fragile
         # TODO: extract this from charm code
@@ -379,9 +380,17 @@ class Operator(CharmBase):
 
 
 def _get_gateway_address_from_svc(svc):
-    """Look up the load balancer address for the ingress gateway.
+    """Returns the gateway service address from a kubernetes Service.
+
     If the gateway isn't available or doesn't have a load balancer address yet,
     returns None.
+
+
+    Args:
+        svc: The lightkube Service object to interrogate
+
+    Returns:
+        (str): The hostname or IP address of the gateway service (or None)
     """
     # return gateway address: hostname or IP; None if not set
     gateway_address = None
@@ -389,12 +398,20 @@ def _get_gateway_address_from_svc(svc):
     if svc.spec.type == "ClusterIP":
         gateway_address = svc.spec.clusterIP
     elif svc.spec.type == "LoadBalancer":
-        gateway_address = _get_gateway_from_loadbalancer(svc)
+        gateway_address = _get_address_from_loadbalancer(svc)
 
     return gateway_address
 
 
-def _get_gateway_from_loadbalancer(svc):
+def _get_address_from_loadbalancer(svc):
+    """Returns a hostname or IP address from a LoadBalancer service.
+
+    Args:
+        svc: The lightkube Service object to interrogate
+
+    Returns:
+          (str): The hostname or IP address of the LoadBalancer service
+    """
     ingresses = svc.status.loadBalancer.ingress
     if len(ingresses) != 1:
         if len(ingresses) == 0:

--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -370,7 +370,8 @@ class Operator(CharmBase):
         # FIXME: service name is hardcoded and depends on the istio gateway application name being
         #  `istio-ingressgateway`.  This is very fragile
         # TODO: extract this from charm code
-        # TODO: What happens if this service does not exist?
+        # TODO: What happens if this service does not exist?  We should check on that and then add
+        #  tests to confirm this works
         svc = self.lightkube_client.get(
             Service, name=GATEWAY_WORKLOAD_SERVICE_NAME, namespace=self.model.name
         )

--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -21,6 +21,7 @@ from resources_handler import ResourceHandler
 GATEWAY_HTTP_PORT = 8080
 GATEWAY_HTTPS_PORT = 8443
 METRICS_PORT = 15014
+GATEWAY_WORKLOAD_SERVICE_NAME = "istio-ingressgateway-workload"
 
 
 class Operator(CharmBase):
@@ -209,7 +210,7 @@ class Operator(CharmBase):
         self.send_info(event)
 
         try:
-            if not self._gateway_address:
+            if not self._is_gateway_service_up():
                 self.log.info(
                     "No gateway address returned - this may be transitory, but "
                     "if it persists it is likely an unexpected error. "
@@ -352,35 +353,61 @@ class Operator(CharmBase):
         else:
             return exporter_ip
 
-    @property
-    def _gateway_address(self):
-        """Look up the load balancer address for the ingress gateway.
-        If the gateway isn't available or doesn't have a load balancer address yet,
-        returns None.
-        """
-        # FIXME: service name is hardcoded
+    def _is_gateway_service_up(self):
+        """Returns True if the gateway is up, else False."""
+        svc = self._get_gateway_service()
+
+        if svc.spec.type == "NodePort":
+            # TODO: do we need to interrogate this further for status?
+            return True
+        else:
+            if _get_gateway_address_from_svc(svc) is not None:
+                return True
+            else:
+                return False
+
+    def _get_gateway_service(self):
+        # FIXME: service name is hardcoded and depends on the istio gateway application name being
+        #  `istio-ingressgateway`.  This is very fragile
         # TODO: extract this from charm code
-        svcs = self.lightkube_client.get(
-            Service, name="istio-ingressgateway-workload", namespace=self.model.name
+        # TODO: What happens if this service does not exist?
+        svc = self.lightkube_client.get(
+            Service, name=GATEWAY_WORKLOAD_SERVICE_NAME, namespace=self.model.name
         )
+        return svc
 
-        # return gateway address: hostname or IP; None if not set
-        gateway_address = None
 
-        if svcs.spec.type == "ClusterIP":
-            gateway_address = svcs.spec.clusterIP
-        elif (
-            hasattr(svcs.status.loadBalancer.ingress[0], "hostname")
-            and svcs.status.loadBalancer.ingress[0].hostname is not None
-        ):
-            gateway_address = svcs.status.loadBalancer.ingress[0].hostname
-        elif (
-            hasattr(svcs.status.loadBalancer.ingress[0], "ip")
-            and svcs.status.loadBalancer.ingress[0].ip is not None
-        ):
-            gateway_address = svcs.status.loadBalancer.ingress[0].ip
+def _get_gateway_address_from_svc(svc):
+    """Look up the load balancer address for the ingress gateway.
+    If the gateway isn't available or doesn't have a load balancer address yet,
+    returns None.
+    """
+    # return gateway address: hostname or IP; None if not set
+    gateway_address = None
 
-        return gateway_address
+    if svc.spec.type == "ClusterIP":
+        gateway_address = svc.spec.clusterIP
+    elif svc.spec.type == "LoadBalancer":
+        gateway_address = _get_gateway_from_loadbalancer(svc)
+
+    return gateway_address
+
+
+def _get_gateway_from_loadbalancer(svc):
+    ingresses = svc.status.loadBalancer.ingress
+    if len(ingresses) != 1:
+        if len(ingresses) == 0:
+            return None
+        else:
+            raise ValueError("Unknown situation - LoadBalancer service has more than one ingress")
+
+    ingress = svc.status.loadBalancer.ingress[0]
+    if getattr(ingress, "hostname", None) is not None:
+        return svc.status.loadBalancer.ingress[0].hostname
+    elif getattr(ingress, "ip", None) is not None:
+        return svc.status.loadBalancer.ingress[0].ip
+    else:
+        raise ValueError("Unknown situation - LoadBalancer service has no hostname or IP")
 
 
 if __name__ == "__main__":

--- a/charms/istio-pilot/tests/unit/test_charm.py
+++ b/charms/istio-pilot/tests/unit/test_charm.py
@@ -97,6 +97,10 @@ def test_basic(harness, subprocess, mocker):
     mocker.patch("lightkube.codecs.load_all_yaml")
     mocker.patch("resources_handler.load_in_cluster_generic_resources")
     check_call = subprocess.check_call
+
+    # Mock _is_gateway_service_up() to simulate that we do see a gateway from istio-ingressgateway
+    mocker.patch("charm.Operator._is_gateway_service_up", return_value=True)
+
     harness.set_leader(True)
     harness.begin_with_initial_hooks()
 
@@ -119,6 +123,9 @@ def test_basic(harness, subprocess, mocker):
 
 def test_with_ingress_relation(harness, subprocess, mocked_client, helpers, mocker, mocked_list):
     check_call = subprocess.check_call
+    # Mock _is_gateway_service_up() to simulate that we do see a gateway from istio-ingressgateway
+    mocker.patch("charm.Operator._is_gateway_service_up", return_value=True)
+
     harness.set_leader(True)
 
     rel_id = harness.add_relation("ingress", "app")

--- a/charms/istio-pilot/tests/unit/test_charm.py
+++ b/charms/istio-pilot/tests/unit/test_charm.py
@@ -604,24 +604,3 @@ def test_get_gateway_address_from_svc(mock_service_fixture, gateway_address, har
     mock_service = request.getfixturevalue(mock_service_fixture)
 
     assert _get_gateway_address_from_svc(svc=mock_service) is gateway_address
-
-
-def test_clusterip_service(harness, subprocess, mocked_client, helpers, mocker, mocked_list):
-    """Test that the charm._gateway_address correctly returns gateway service IP/hostname."""
-
-    mocker.patch("resources_handler.load_in_cluster_generic_resources")
-    harness.set_leader(True)
-    harness.begin()
-
-    # Test retrieval of gateway address set in Service
-    harness.charm.lightkube_client.get.side_effect = [
-        codecs.from_dict(
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "status": {"loadBalancer": {}},
-                "spec": {"type": "ClusterIP", "clusterIP": "10.10.10.10"},
-            }
-        )
-    ]
-    assert harness.charm._gateway_address == "10.10.10.10"

--- a/charms/istio-pilot/tests/unit/test_charm.py
+++ b/charms/istio-pilot/tests/unit/test_charm.py
@@ -1,4 +1,5 @@
-from unittest.mock import call as Call, MagicMock  # noqa: N812
+from unittest.mock import MagicMock
+from unittest.mock import call as Call  # noqa: N812
 
 import pytest
 import yaml
@@ -6,6 +7,7 @@ from lightkube import codecs
 from lightkube.core.exceptions import ApiError
 from lightkube.generic_resource import create_global_resource
 from ops.model import ActiveStatus, WaitingStatus
+
 from charm import _get_gateway_address_from_svc
 
 
@@ -576,12 +578,14 @@ def mock_loadbalancer_hostname_service_not_ready():
         ("mock_loadbalancer_ip_service", True),
         ("mock_loadbalancer_hostname_service_not_ready", False),
         ("mock_loadbalancer_ip_service_not_ready", False),
-    ]
+    ],
 )
 def test_is_gateway_service_up(mock_service_fixture, is_gateway_up, harness, request):
     harness.begin()
 
-    mock_get_gateway_service = MagicMock(return_value=request.getfixturevalue(mock_service_fixture))
+    mock_get_gateway_service = MagicMock(
+        return_value=request.getfixturevalue(mock_service_fixture)
+    )
 
     harness.charm._get_gateway_service = mock_get_gateway_service
     assert harness.charm._is_gateway_service_up() is is_gateway_up
@@ -597,9 +601,19 @@ def test_is_gateway_service_up(mock_service_fixture, is_gateway_up, harness, req
         ("mock_loadbalancer_ip_service", "127.0.0.1"),
         ("mock_loadbalancer_hostname_service_not_ready", None),
         ("mock_loadbalancer_ip_service_not_ready", None),
-    ]
+    ],
 )
-def test_get_gateway_address_from_svc(mock_service_fixture, gateway_address, harness, subprocess, mocked_client, helpers, mocker, mocked_list, request):
+def test_get_gateway_address_from_svc(
+    mock_service_fixture,
+    gateway_address,
+    harness,
+    subprocess,
+    mocked_client,
+    helpers,
+    mocker,
+    mocked_list,
+    request,
+):
     """Test that the charm._gateway_address correctly returns gateway service IP/hostname."""
     mock_service = request.getfixturevalue(mock_service_fixture)
 

--- a/charms/istio-pilot/tests/unit/test_charm.py
+++ b/charms/istio-pilot/tests/unit/test_charm.py
@@ -595,6 +595,8 @@ def test_get_gateway_service():
     "mock_service_fixture, gateway_address",
     [
         # Pass fixtures by their names
+        ("mock_nodeport_service", None),
+        ("mock_clusterip_service", "10.10.10.10"),
         ("mock_loadbalancer_hostname_service", "test.com"),
         ("mock_loadbalancer_ip_service", "127.0.0.1"),
         ("mock_loadbalancer_hostname_service_not_ready", None),
@@ -606,25 +608,6 @@ def test_get_gateway_address_from_svc(mock_service_fixture, gateway_address, har
     mock_service = request.getfixturevalue(mock_service_fixture)
 
     assert _get_gateway_address_from_svc(svc=mock_service) is gateway_address
-
-
-def test_gateway_address_for_nodeport(harness, subprocess, mocked_client, mocker):
-    """Test that the charm._gateway_address correctly returns None for a nodeport service."""
-    mocker.patch("resources_handler.load_in_cluster_generic_resources")
-    harness.set_leader(True)
-    harness.begin()
-
-    harness.charm.lightkube_client.get.side_effect = [
-        codecs.from_dict(
-            {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "status": {"loadBalancer": {}},
-                "spec": {"type": "NodePort", "clusterIP": "10.10.10.10"},
-            }
-        )
-    ]
-    assert harness.charm._gateway_address == None
 
 
 def test_clusterip_service(harness, subprocess, mocked_client, helpers, mocker, mocked_list):

--- a/charms/istio-pilot/tests/unit/test_charm.py
+++ b/charms/istio-pilot/tests/unit/test_charm.py
@@ -587,10 +587,6 @@ def test_is_gateway_service_up(mock_service_fixture, is_gateway_up, harness, req
     assert harness.charm._is_gateway_service_up() is is_gateway_up
 
 
-def test_get_gateway_service():
-    raise NotImplementedError("add error validation here, too")
-
-
 @pytest.mark.parametrize(
     "mock_service_fixture, gateway_address",
     [


### PR DESCRIPTION
## Context

#175 and elsewhere requests that the `istio-gateway` charm allow for access through a `NodePort` rather than just through a `LoadBalancer` or `ClusterIP`.  This feature is implemented here, where add another valid entry for `gateway_service_type`, `gateway_service_type=NodePort`

Because of how `istio-pilot` was using the service provided by `istio-gateway`, we also need to change some of the logic around how `istio-pilot` interrogates the gateway it finds.  Included here too are these changes, as well as an expanded test suite.

See #175 for more context.  closes #175

## Testing instructions

Note that these instructions use charmhub `edge/branch` charms.  If you don't have access to the charmhub branch charms, you must build istio-pilot and istio-gateway for yourself locally.

(edited Feb 22 to fix the auth config)

```
juju add-model kubeflow

# Deploy `istio-pilot` and `istio-gateway`, where `istio-gateway` uses the `gateway_service_type=NodePort`
juju deploy istio-pilot --channel=edge/add-gateway-nodeport --trust --series kubernetes
juju deploy istio-gateway --channel=edge/add-gateway-nodeport --trust --config kind=ingress --config gateway_service_type=NodePort istio-ingressgateway --series kubernetes
juju relate istio-pilot istio-gateway
# Charms should go to Active

# Look for the gateway service, which should be of type nodeport:
kubectl get svc -n kubeflow | grep istio-ingressgateway-workload
# should see something like:
# istio-ingressgateway-workload    NodePort    10.152.183.121   <none>        80:32693/TCP,443:30358/TCP              23m
# Where the "80:XXXXX/TCP" shows what port is open for regular http traffic (used below as NODEPORT)


# Deploy some things that we can access through the NodePort to confirm it works
juju deploy kubeflow-dashboard --channel edge --trust
juju deploy kubeflow-profiles --channel edge --trust
juju relate kubeflow-dashboard kubeflow-profiles
juju relate kubeflow-dashboard istio-pilot
juju relate kubeflow-dashboard:ingress istio-pilot:ingress
# Charms should go to Active

juju deploy kubeflow-volumes --channel 1.6/stable
juju relate kubeflow-volumes:ingress istio-pilot:ingress
# Charms should go to Active

# Test access via nodeport
# In a browser, browse to `YOUR_LOCAL_IP:NODEPORT`.  You should be able to access the dashboard (likely after creating a user profile)
# You can then also click on `Volumes` in the sidebar and it should work as well

# Add authentication into the loop
juju deploy dex-auth --channel=2.31/edge --trust --config static-username=user2 --config static-password=user2 --config public-url=http://YOUR_LOCAL_IP:NODEPORT
juju deploy oidc-gatekeeper --channel ckf-1.6/edge --config public-url=http://YOUR_LOCAL_IP:NODEPORT
juju relate istio-pilot:ingress dex-auth:ingress
juju relate dex-auth:oidc-client oidc-gatekeeper:oidc-client
juju relate istio-pilot:ingress oidc-gatekeeper:ingress
juju relate istio-pilot:ingress-auth oidc-gatekeeper:ingress-auth
# Wait for everything to get back to Active

# Browse to `http://YOUR_LOCAL_IP.nip.io:NODEPORT/` to see your dashboard 
```

Todo:
* [ ] For documentation (a how-to guide?), include a warning about using nodeport.  With our OIDC/dex setup, all connections will have to go through a single node (we can't set multiple `public-url`s).  That's fine for a single node or small cluster, but not good for a larger cluster.  Larger usages should have a proper load balancer up front.