### PR TITLE
feat: unpin juju agent-version

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -82,8 +82,7 @@ jobs:
 
     - name: Bootstrap
       run: |
-        # Pinned until this bug is resolved: https://bugs.launchpad.net/juju/+bug/1992833
-        sg microk8s -c 'juju bootstrap microk8s uk8s --agent-version=2.9.34'
+        sg microk8s -c 'juju bootstrap microk8s uk8s'
         sg microk8s -c 'juju add-model istio-system'
 
     - run: sg microk8s -c 'KUBECONFIG=/home/runner/.kube/config tox -e integration
@@ -143,9 +142,6 @@ jobs:
         with:
           provider: microk8s
           channel: 1.24/stable
-          # Pinned to 2.9.34 due to https://bugs.launchpad.net/juju/+bug/1992833
-          # This should be fixed on release of juju 2.9.36 + libjuju 3.0.3
-          bootstrap-options: --agent-version="2.9.34"
       - run: sg microk8s -c "microk8s enable metallb:'10.64.140.43-10.64.140.49,192.168.0.105-192.168.0.111'"
       - run: juju add-model cos-test
 


### PR DESCRIPTION
juju `agent-version` was previously pinned to 2.9.34 due to https://bugs.launchpad.net/juju/+bug/1992833.  This has been resolved.