### PR TITLE
ci: bump juju agent 2.9.34 -> 2.9.42 (#200)

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -82,8 +82,8 @@ jobs:
 
     - name: Bootstrap
       run: |
-        # Pinned until this bug is resolved: https://bugs.launchpad.net/juju/+bug/1992833
-        sg microk8s -c 'juju bootstrap microk8s uk8s --agent-version=2.9.34'
+        # Pinning juju agent to 2.9.42 to keep compatibility with pythonlib-juju<3
+        sg microk8s -c 'juju bootstrap microk8s uk8s --agent-version=2.9.42'
         sg microk8s -c 'juju add-model istio-system'
 
     - run: sg microk8s -c 'KUBECONFIG=/home/runner/.kube/config tox -e integration
@@ -143,9 +143,8 @@ jobs:
         with:
           provider: microk8s
           channel: 1.24/stable
-          # Pinned to 2.9.34 due to https://bugs.launchpad.net/juju/+bug/1992833
-          # This should be fixed on release of juju 2.9.36 + libjuju 3.0.3
-          bootstrap-options: --agent-version="2.9.34"
+          # Pinning juju agent to 2.9.42 to keep compatibility with pythonlib-juju<3
+          bootstrap-options: --agent-version="2.9.42"
       - run: sg microk8s -c "microk8s enable metallb:'10.64.140.43-10.64.140.49,192.168.0.105-192.168.0.111'"
       - run: juju add-model cos-test
 

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -61,11 +61,12 @@ async def test_deploy_istio_charms(ops_test: OpsTest):
     istio_charms = await ops_test.build_charms(f"{charms_path}-gateway", f"{charms_path}-pilot")
 
     await ops_test.model.deploy(
-        istio_charms["istio-pilot"], application_name=ISTIO_PILOT, trust=True
+        istio_charms["istio-pilot"], application_name=ISTIO_PILOT, series="focal", trust=True
     )
     await ops_test.model.deploy(
         istio_charms["istio-gateway"],
         application_name=ISTIO_GATEWAY_APP_NAME,
+        series="focal",
         config={"kind": "ingress"},
         trust=True,
     )

--- a/tests/test_cos_integration.py
+++ b/tests/test_cos_integration.py
@@ -25,11 +25,12 @@ async def test_deploy_istio_charms(ops_test: OpsTest):
     istio_charms = await ops_test.build_charms(f"{charms_path}-gateway", f"{charms_path}-pilot")
 
     await ops_test.model.deploy(
-        istio_charms["istio-pilot"], application_name=ISTIO_PILOT, trust=True
+        istio_charms["istio-pilot"], application_name=ISTIO_PILOT, series="focal", trust=True
     )
     await ops_test.model.deploy(
         istio_charms["istio-gateway"],
         application_name=ISTIO_INGRESSGATEWAY,
+        series="focal",
         config={"kind": "ingress"},
         trust=True,
     )


### PR DESCRIPTION
The bug[1] in juju that was forcing us to pin the agent to version 2.9.34 is fixed now in 2.9.42. This commit bumps the agent version and adds the "series" field in deploy statements in tests so we can use the new juju agent version.

[1] https://bugs.launchpad.net/juju/+bug/1992833
* ci: bump juju agent 2.9.34 -> 2.9.42
* tests: add series=focal when deploying istio