### PR TITLE
fix: patches misconfigured ValidatingWebhook on Install

### DIFF
--- a/charms/istio-pilot/tests/unit/test_charm.py
+++ b/charms/istio-pilot/tests/unit/test_charm.py
@@ -763,6 +763,9 @@ def test_patch_istio_validating_webhook(harness, mocker):
     """Tests that _patch_istio_validating_webhook works as expected."""
     model_name = "test-model"
     harness.set_model_name(model_name)
+    harness.set_leader(True)
+    # Avoid initialising the resource handler
+    mocker.patch("resources_handler.load_in_cluster_generic_resources")
     harness.begin()
 
     mock_vwc = ValidatingWebhookConfiguration(


### PR DESCRIPTION
This extends the patch for #204 to fix install events.  Prior to this patch, istioctl for v1.12-1.14 creates a ValidatingWebhookConfiguration that points to istiod in the istio-system namespace rather than the namespace where istiod is deployed.