### PR TITLE
add istio-gateway helpers to istio-pilot event handler rewrite

### DIFF
--- a/charms/istio-pilot/config.yaml
+++ b/charms/istio-pilot/config.yaml
@@ -3,6 +3,10 @@ options:
     type: string
     default: istio-gateway
     description: Name to use as a default gateway
+  gateway-service-name:
+    type: string
+    default: istio-ingressgateway-workload
+    description: Name of the service created by istio-gateway to use as a Gateway
   ssl-crt:
     type: string
     default: ''

--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -358,19 +358,6 @@ class Operator(CharmBase):
         )
         return svc
 
-    def _is_gateway_service_up(self):
-        """Returns True if the ingress gateway service is up, else False."""
-        # TODO: This should really be something provided via a relation to istio-gateway, where it
-        #  tells us if things are working.
-        svc = self._get_gateway_service()
-
-        if svc.spec.type == "NodePort":
-            # TODO: do we need to interrogate this further for status?
-            return True
-        if _get_gateway_address_from_svc(svc) is not None:
-            return True
-        return False
-
     def _send_gateway_info(self):
         """Sends gateway information to all related apps."""
         # TODO: Can any of this be put into the lib?
@@ -419,6 +406,20 @@ class Operator(CharmBase):
         """
         # TODO: Set Active otherwise?  Call a "check my status" function if we have no errors?
         raise NotImplementedError()
+
+    @property
+    def _is_gateway_service_up(self):
+        """Returns True if the ingress gateway service is up, else False."""
+        # TODO: This should really be something provided via a relation to istio-gateway, where it
+        #  tells us if things are working.
+        svc = self._get_gateway_service()
+
+        if svc.spec.type == "NodePort":
+            # TODO: do we need to interrogate this further for status?
+            return True
+        if _get_gateway_address_from_svc(svc) is not None:
+            return True
+        return False
 
     @property
     def _istiod_svc(self):

--- a/charms/istio-pilot/tests/unit/test_charm.py
+++ b/charms/istio-pilot/tests/unit/test_charm.py
@@ -115,7 +115,7 @@ class TestCharmHelpers:
         )
 
         harness.charm._get_gateway_service = mock_get_gateway_service
-        assert harness.charm._is_gateway_service_up() is is_gateway_up
+        assert harness.charm._is_gateway_service_up is is_gateway_up
 
     @pytest.mark.parametrize(
         "mock_service_fixture, gateway_address",


### PR DESCRIPTION
This is based on #234.  Recommended that this be reviewed after #234 is merged as that accounts for most of the changes.  This is part of a larger effort to refactor istio-pilot's event handling, as described [in jira](https://warthogs.atlassian.net/browse/KF-728). This merges into a feature branch and covers only part of the total effort.

Includes:
* helpers that check on istio-gateway's service
* tests for helpers
* added a config option for the istio-gateway's service name to make things easier to test and deploy