### PR TITLE
add istio-pilot ingress-auth reconciler to event handler rewrite

### DIFF
--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -334,6 +334,17 @@ class Operator(CharmBase):
             self.log.info("Not a leader, skipping setup")
             raise ErrorWithStatus("Waiting for leadership", WaitingStatus)
 
+    @property
+    def _gateway_port(self):
+        if _xor(self.model.config["ssl-crt"], self.model.config["ssl-key"]):
+            # Fail if ssl is only partly configured as this is probably a mistake
+            raise ErrorWithStatus("Charm config for ssl-crt and ssl-key must either both be set or unset", BlockedStatus)
+
+        if self.model.config["ssl-crt"] and self.model.config["ssl-key"]:
+            return GATEWAY_HTTPS_PORT
+        else:
+            return GATEWAY_HTTP_PORT
+
     def _get_interfaces(self):
         """Retrieve interface object."""
         try:
@@ -637,6 +648,14 @@ def _wait_for_update_rollout(
                     f" version - upgrade rollout complete"
                 )
     return versions
+
+
+def _xor(a, b):
+    """Returns True if exactly one of a and b is True, else False."""
+    if (a and not b) or (b and not a):
+        return True
+    else:
+        return False
 
 
 if __name__ == "__main__":

--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -13,7 +13,12 @@ from ops.charm import CharmBase
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 from packaging.version import Version
-from serialized_data_interface import NoCompatibleVersions, NoVersionsListed, get_interfaces
+from serialized_data_interface import (
+    NoCompatibleVersions,
+    NoVersionsListed,
+    get_interface,
+    get_interfaces,
+)
 
 from istio_gateway_info_provider import RELATION_NAME as GATEWAY_INFO_RELATION_NAME
 from istio_gateway_info_provider import GatewayProvider
@@ -22,6 +27,7 @@ from istioctl import Istioctl, IstioctlError
 GATEWAY_HTTP_PORT = 8080
 GATEWAY_HTTPS_PORT = 8443
 METRICS_PORT = 15014
+INGRESS_AUTH_RELATION_NAME = "ingress-auth"
 ISTIOCTL_PATH = "./istioctl"
 ISTIOCTL_DEPOYMENT_PROFILE = "minimal"
 UPGRADE_FAILED_MSG = (
@@ -344,7 +350,32 @@ class Operator(CharmBase):
         This is a workaround to ensure that errors in other relation data, such as an incomplete
         ingress relation, do not block us from retrieving the ingress-auth data.
         """
-        raise NotImplementedError()
+        try:
+            ingress_auth_interface = get_interface(self, INGRESS_AUTH_RELATION_NAME)
+        except NoVersionsListed as err:
+            raise ErrorWithStatus(err, WaitingStatus)
+        except NoCompatibleVersions as err:
+            raise ErrorWithStatus(err, BlockedStatus)
+
+        # Filter out data we sent out.
+        if ingress_auth_interface:
+            ingress_auth_data = {
+                (rel, app): route
+                for (rel, app), route in sorted(
+                    ingress_auth_interface.get_data().items(), key=lambda tup: tup[0][0].id
+                )
+                if app != self.app
+            }
+        else:
+            # If there is no ingress-auth relation, we have no data here
+            ingress_auth_data = {}
+
+        if len(ingress_auth_data) > 1:
+            raise ErrorWithStatus(
+                "Multiple ingress-auth relations are not supported", BlockedStatus
+            )
+
+        return ingress_auth_data
 
     def _get_gateway_service(self):
         """Returns a lightkube Service object for the gateway service."""

--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -5,10 +5,10 @@ import subprocess
 
 import tenacity
 from charmed_kubeflow_chisme.exceptions import ErrorWithStatus, GenericCharmRuntimeError
-from charmed_kubeflow_chisme.lightkube.batch import delete_many
 from charmed_kubeflow_chisme.kubernetes import KubernetesResourceHandler
 from lightkube import Client
 from lightkube.core.exceptions import ApiError
+from lightkube.generic_resource import create_namespaced_resource
 from lightkube.resources.admissionregistration_v1 import ValidatingWebhookConfiguration
 from lightkube.resources.core_v1 import Service
 from ops.charm import CharmBase
@@ -443,14 +443,24 @@ class Operator(CharmBase):
         If ingress_auth_data is an empty dict, this results in any existing ingress-auth
         EnvoyFilter previously deployed here to be deleted.
 
-        Note that this function supports only ingress_auth_data with a single entry.  If we
-        support multiple entries, this needs refactoring
+        Limitations:
+            * this function supports only ingress_auth_data with a single entry.  If we support
+              multiple entries, this needs refactoring
+            * the auth_filter yaml template has a hard-coded workloadSelector for the Gateway
         """
+        envoyfilter_name = f"{self.app.name}-authn-filter"
+
+        if len(ingress_auth_data) == 0:
+            self.log.info("No ingress-auth data found - deleting any existing EnvoyFilter")
+            _remove_envoyfilter(envoyfilter_name)
+            return
+
         context = {
+            "auth_service_name": ingress_auth_data['service'],
+            "auth_service_namespace": self.model.name,  # Assumed to be in the same namespace
             "app_name": self.app.name,
+            "envoyfilter_name": envoyfilter_name,
             "gateway_port": self._gateway_port,
-            "gateway_service_name": self.model.config["gateway-service-name"] + "NOT REALLLLLLL",  # TODO: WHAT IS THIS????
-            "gateway_service_namespace": self.model.name,
             "port": ingress_auth_data['port'],
             "request_headers": ingress_auth_data['request_headers'],
             "response_headers": ingress_auth_data['response_headers'],
@@ -462,11 +472,6 @@ class Operator(CharmBase):
             context=context,
             logger=self.log
         )
-
-        if len(ingress_auth_data) == 0:
-            self.log.info("No ingress-auth data found - deleting any existing EnvoyFilter")
-            delete_many(krh.lightkube_client, krh.render_manifests())
-            return
 
         krh.apply()
 
@@ -617,6 +622,24 @@ def _get_address_from_loadbalancer(svc):
         return svc.status.loadBalancer.ingress[0].ip
     else:
         raise ValueError("Unknown situation - LoadBalancer service has no hostname or IP")
+
+
+def _remove_envoyfilter(name: str, namespace: str):
+    """Remove an EnvoyFilter resource.
+
+    Args:
+        name: The name of the EnvoyFilter resource to remove
+    """
+    envoyfilter_resource = create_namespaced_resource(
+        group="networking.istio.io", version="v1alpha3", kind="EnvoyFilter", plural="envoyfilters"
+    )
+    lightkube_client = Client()
+    try:
+        lightkube_client.delete(envoyfilter_resource, name=name, namespace=namespace)
+    except ApiError as e:
+        if e.status.code == 404:
+            return
+        raise e
 
 
 def _validate_upgrade_version(versions) -> bool:

--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -5,6 +5,8 @@ import subprocess
 
 import tenacity
 from charmed_kubeflow_chisme.exceptions import ErrorWithStatus, GenericCharmRuntimeError
+from charmed_kubeflow_chisme.lightkube.batch import delete_many
+from charmed_kubeflow_chisme.kubernetes import KubernetesResourceHandler
 from lightkube import Client
 from lightkube.core.exceptions import ApiError
 from lightkube.resources.admissionregistration_v1 import ValidatingWebhookConfiguration
@@ -28,6 +30,7 @@ GATEWAY_HTTP_PORT = 8080
 GATEWAY_HTTPS_PORT = 8443
 METRICS_PORT = 15014
 INGRESS_AUTH_RELATION_NAME = "ingress-auth"
+INGRESS_AUTH_TEMPLATE_FILES = ["manifests/auth_filter.yaml.j2"]
 ISTIOCTL_PATH = "./istioctl"
 ISTIOCTL_DEPOYMENT_PROFILE = "minimal"
 UPGRADE_FAILED_MSG = (
@@ -180,8 +183,8 @@ class Operator(CharmBase):
 
         ingress_auth_reconcile_successful = False
         try:
-            ingress_auth = self._get_ingress_auth_data()
-            self._reconcile_ingress_auth(ingress_auth)
+            ingress_auth_data = self._get_ingress_auth_data()
+            self._reconcile_ingress_auth(ingress_auth_data)
             ingress_auth_reconcile_successful = True
         except ErrorWithStatus as err:
             handled_errors.append(err)
@@ -395,6 +398,9 @@ class Operator(CharmBase):
         #  assuming the name.
         # TODO: What happens if this service does not exist?  We should check on that and then add
         #  tests to confirm this works
+
+        # Note: this assumes that the gateway service is deployed in the same namespace as this
+        # charm
         svc = self.lightkube_client.get(
             Service, name=self.model.config["gateway-service-name"], namespace=self.model.name
         )
@@ -431,11 +437,38 @@ class Operator(CharmBase):
         #  else's
         raise NotImplementedError()
 
-    def _reconcile_ingress_auth(self, ingress_auth_interface):
-        """Reconcile the EnvoyFilter which is controlled by the ingress-auth relation data."""
-        # If there is no ingress_auth data, this should result in any existing EnvoyFilter being
-        # deleted.  Document that side effect
-        raise NotImplementedError()
+    def _reconcile_ingress_auth(self, ingress_auth_data: dict):
+        """Reconcile the EnvoyFilter which is controlled by the ingress-auth relation data.
+
+        If ingress_auth_data is an empty dict, this results in any existing ingress-auth
+        EnvoyFilter previously deployed here to be deleted.
+
+        Note that this function supports only ingress_auth_data with a single entry.  If we
+        support multiple entries, this needs refactoring
+        """
+        context = {
+            "app_name": self.app.name,
+            "gateway_port": self._gateway_port,
+            "gateway_service_name": self.model.config["gateway-service-name"] + "NOT REALLLLLLL",  # TODO: WHAT IS THIS????
+            "gateway_service_namespace": self.model.name,
+            "port": ingress_auth_data['port'],
+            "request_headers": ingress_auth_data['request_headers'],
+            "response_headers": ingress_auth_data['response_headers'],
+        }
+
+        krh = KubernetesResourceHandler(
+            field_manager=self.app.name,
+            template_files=INGRESS_AUTH_TEMPLATE_FILES,
+            context=context,
+            logger=self.log
+        )
+
+        if len(ingress_auth_data) == 0:
+            self.log.info("No ingress-auth data found - deleting any existing EnvoyFilter")
+            delete_many(krh.lightkube_client, krh.render_manifests())
+            return
+
+        krh.apply()
 
     def _remove_gateway(self):
         """Remove the Gateway resource."""

--- a/charms/istio-pilot/src/manifests/auth_filter.yaml.j2
+++ b/charms/istio-pilot/src/manifests/auth_filter.yaml.j2
@@ -2,7 +2,7 @@
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
-  name: {{ app_name }}-authn-filter
+  name: {{ envoyfilter_name }}
   labels:
     app.{{ app_name }}.io/is-workload-entity: "true"
 spec:
@@ -25,8 +25,8 @@ spec:
             '@type': type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
             http_service:
               server_uri:
-                uri: http://{{ gateway_service_name }}.{{ gateway_service_namespace }}.svc.cluster.local:{{ port }}
-                cluster: outbound|{{ port }}||{{ gateway_service_name }}.{{ gateway_service_namespace }}.svc.cluster.local
+                uri: http://{{ auth_service_name }}.{{ auth_service_namespace }}.svc.cluster.local:{{ port }}
+                cluster: outbound|{{ port }}||{{ auth_service_name }}.{{ auth_service_namespace }}.svc.cluster.local
                 timeout: 10s
               authorization_request:
                 allowed_headers:

--- a/charms/istio-pilot/src/manifests/auth_filter.yaml.j2
+++ b/charms/istio-pilot/src/manifests/auth_filter.yaml.j2
@@ -2,7 +2,7 @@
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
-  name: authn-filter
+  name: {{ app_name }}-authn-filter
   labels:
     app.{{ app_name }}.io/is-workload-entity: "true"
 spec:
@@ -25,8 +25,8 @@ spec:
             '@type': type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
             http_service:
               server_uri:
-                uri: http://{{ service }}.{{ namespace }}.svc.cluster.local:{{ port }}
-                cluster: outbound|{{ port }}||{{ service }}.{{ namespace }}.svc.cluster.local
+                uri: http://{{ gateway_service_name }}.{{ gateway_service_namespace }}.svc.cluster.local:{{ port }}
+                cluster: outbound|{{ port }}||{{ gateway_service_name }}.{{ gateway_service_namespace }}.svc.cluster.local
                 timeout: 10s
               authorization_request:
                 allowed_headers:

--- a/charms/istio-pilot/tests/unit/test_charm.py
+++ b/charms/istio-pilot/tests/unit/test_charm.py
@@ -1,10 +1,12 @@
 import logging
 from contextlib import nullcontext as does_not_raise
+from typing import Optional
 from unittest.mock import MagicMock, Mock, patch
+import yaml
 
 import pytest
 import tenacity
-from charmed_kubeflow_chisme.exceptions import GenericCharmRuntimeError
+from charmed_kubeflow_chisme.exceptions import ErrorWithStatus, GenericCharmRuntimeError
 from charmed_kubeflow_chisme.lightkube.mocking import FakeApiError
 from lightkube import codecs
 from lightkube.models.admissionregistration_v1 import (
@@ -140,6 +142,45 @@ class TestCharmHelpers:
         mock_service = request.getfixturevalue(mock_service_fixture)
 
         assert _get_gateway_address_from_svc(svc=mock_service) is gateway_address
+
+    def test_get_ingress_auth_data(self, harness):
+        """Tests that the _get_ingress_auth_data helper returns the correct relation data."""
+        harness.begin()
+        returned_data = add_ingress_auth_to_harness(harness)
+
+        ingress_auth_data = harness.charm._get_ingress_auth_data()
+
+        assert len(ingress_auth_data) == 1
+        assert list(ingress_auth_data.values())[0] == returned_data['data']
+
+    def test_get_ingress_auth_data_empty(self, harness):
+        """Tests that the _get_ingress_auth_data helper returns the correct relation data."""
+        harness.begin()
+        ingress_auth_data = harness.charm._get_ingress_auth_data()
+
+        assert len(ingress_auth_data) == 0
+
+    def test_get_ingress_auth_data_too_many_relations(self, harness):
+        """Tests that the _get_ingress_auth_data helper returns the correct relation data."""
+        harness.begin()
+        add_ingress_auth_to_harness(harness, other_app="other1")
+        add_ingress_auth_to_harness(harness, other_app="other2")
+
+        with pytest.raises(ErrorWithStatus) as err:
+            harness.charm._get_ingress_auth_data()
+
+        assert "Multiple ingress-auth" in err.value.msg
+
+    def test_get_ingress_auth_data_waiting_on_version(self, harness):
+        """Tests that the _get_ingress_auth_data helper returns the correct relation data."""
+        harness.begin()
+        harness.add_relation("ingress-auth", "other")
+
+        with pytest.raises(ErrorWithStatus) as err:
+            harness.charm._get_ingress_auth_data()
+
+        assert "versions not found" in err.value.msg
+
 
 
 class TestCharmUpgrade:
@@ -450,6 +491,47 @@ def mocked_lightkube_client_class(mocker):
 
 
 # Helpers
+def add_data_to_sdi_relation(harness: Harness, rel_id: str, other: str, data: Optional[dict] = None, supported_versions: str = "- v1") -> None:
+    """Add data to the an SDI-backed relation."""
+    if data is None:
+        data = {}
+
+    harness.update_relation_data(
+        rel_id,
+        other,
+        {"_supported_versions": supported_versions, "data": yaml.dump(data)},
+    )
+
+
+def add_ingress_auth_to_harness(harness: Harness, other_app="other") -> dict:
+    """Relates a new app and unit to the ingress-auth relation.
+
+    Returns dict of:
+    * other (str): The name of the other app
+    * other_unit (str): The name of the other unit
+    * rel_id (int): The relation id
+    * data (dict): The relation data put to the relation
+    """
+    other_unit=f"{other_app}/0"
+    rel_id = harness.add_relation("ingress-auth", other_app)
+
+    harness.add_relation_unit(rel_id, other_unit)
+    data = {
+        "service": "service-name",
+        "port": 6666,
+        "allowed-request-headers": ["foo"],
+        "allowed-response-headers": ["bar"],
+    }
+    add_data_to_sdi_relation(harness, rel_id, other_app, data)
+
+    return {
+        "other": other_app,
+        "other_unit": other_unit,
+        "rel_id": rel_id,
+        "data": data,
+    }
+
+
 def assert_called_once_and_reset(mock: Mock):
     mock.assert_called_once()
     mock.reset_mock()

--- a/charms/istio-pilot/tests/unit/test_charm.py
+++ b/charms/istio-pilot/tests/unit/test_charm.py
@@ -2,10 +2,10 @@ import logging
 from contextlib import nullcontext as does_not_raise
 from typing import Optional
 from unittest.mock import MagicMock, Mock, patch
-import yaml
 
 import pytest
 import tenacity
+import yaml
 from charmed_kubeflow_chisme.exceptions import ErrorWithStatus, GenericCharmRuntimeError
 from charmed_kubeflow_chisme.lightkube.mocking import FakeApiError
 from lightkube import codecs
@@ -26,9 +26,10 @@ from charm import (
     GATEWAY_HTTPS_PORT,
     Operator,
     _get_gateway_address_from_svc,
+    _remove_envoyfilter,
     _validate_upgrade_version,
     _wait_for_update_rollout,
-    _xor, _remove_envoyfilter,
+    _xor,
 )
 from istioctl import IstioctlError
 
@@ -108,7 +109,7 @@ class TestCharmHelpers:
             ("x", "x", GATEWAY_HTTPS_PORT, does_not_raise()),
             ("x", "", None, pytest.raises(ErrorWithStatus)),
             ("", "x", None, pytest.raises(ErrorWithStatus)),
-        ]
+        ],
     )
     def test_gateway_port(self, ssl_crt, ssl_key, expected_port, expected_context, harness):
         harness.begin()
@@ -172,7 +173,7 @@ class TestCharmHelpers:
         ingress_auth_data = harness.charm._get_ingress_auth_data()
 
         assert len(ingress_auth_data) == 1
-        assert list(ingress_auth_data.values())[0] == returned_data['data']
+        assert list(ingress_auth_data.values())[0] == returned_data["data"]
 
     def test_get_ingress_auth_data_empty(self, harness):
         """Tests that the _get_ingress_auth_data helper returns the correct relation data."""
@@ -207,10 +208,10 @@ class TestCharmHelpers:
         """Tests that the _reconcile_ingress_auth helper succeeds when expected."""
         mocked_krh = mocked_kubernetes_resource_handler_class.return_value
         ingress_auth_data = {
-            'port': 1234,
-            'service': 'some-service',
-            'request_headers': 'header1',
-            'response_headers': 'header2',
+            "port": 1234,
+            "service": "some-service",
+            "request_headers": "header1",
+            "response_headers": "header2",
         }
         harness.begin()
 
@@ -220,7 +221,9 @@ class TestCharmHelpers:
 
     @patch("charm._remove_envoyfilter")
     @patch("charm.KubernetesResourceHandler", return_value=MagicMock())
-    def test_reconcile_ingress_auth_no_auth(self, _mocked_kubernetes_resource_handler_class, mocked_remove_envoyfilter, harness):
+    def test_reconcile_ingress_auth_no_auth(
+        self, _mocked_kubernetes_resource_handler_class, mocked_remove_envoyfilter, harness
+    ):
         """Tests that the _reconcile_ingress_auth removes the EnvoyFilter when expected."""
         ingress_auth_data = {}
         harness.begin()
@@ -244,11 +247,13 @@ class TestCharmHelpers:
         "error_code, context_raised",
         [
             (999, pytest.raises(ApiError)),  # Generic ApiErrors are raised
-            (404, does_not_raise())  # 404 errors are ignored
-        ]
+            (404, does_not_raise()),  # 404 errors are ignored
+        ],
     )
     @patch("charm.Client", return_value=MagicMock())
-    def test_remove_envoyfilter_error_handling(self, mocked_lightkube_client_class, error_code, context_raised):
+    def test_remove_envoyfilter_error_handling(
+        self, mocked_lightkube_client_class, error_code, context_raised
+    ):
         """Test that _renove_envoyfilter handles errors as expected."""
         name = "test"
         namespace = "test-namespace"
@@ -258,7 +263,6 @@ class TestCharmHelpers:
         with context_raised:
             _remove_envoyfilter(name, namespace)
 
-
     @pytest.mark.parametrize(
         "left, right, expected",
         [
@@ -266,7 +270,7 @@ class TestCharmHelpers:
             (False, True, True),
             (True, True, False),
             (False, False, False),
-        ]
+        ],
     )
     def test_xor(self, left, right, expected):
         """Test that the xor helper function works as expected."""
@@ -581,7 +585,13 @@ def mocked_lightkube_client_class(mocker):
 
 
 # Helpers
-def add_data_to_sdi_relation(harness: Harness, rel_id: str, other: str, data: Optional[dict] = None, supported_versions: str = "- v1") -> None:
+def add_data_to_sdi_relation(
+    harness: Harness,
+    rel_id: str,
+    other: str,
+    data: Optional[dict] = None,
+    supported_versions: str = "- v1",
+) -> None:
     """Add data to the an SDI-backed relation."""
     if data is None:
         data = {}
@@ -602,7 +612,7 @@ def add_ingress_auth_to_harness(harness: Harness, other_app="other") -> dict:
     * rel_id (int): The relation id
     * data (dict): The relation data put to the relation
     """
-    other_unit=f"{other_app}/0"
+    other_unit = f"{other_app}/0"
     rel_id = harness.add_relation("ingress-auth", other_app)
 
     harness.add_relation_unit(rel_id, other_unit)


### PR DESCRIPTION
This is based on #235.  Recommended that this be reviewed after #235 is merged as that accounts for some of the deltas.  This is part of a larger effort to refactor istio-pilot's event handling, as described [in jira](https://warthogs.atlassian.net/browse/KF-728). This merges into a feature branch and covers only part of the total effort.

Includes:
* _reconcile_ingress_auth
* related ingress-auth helpers
* tests