### PR TITLE
refactor: include provider class in gateway-info library

### DIFF
--- a/charms/istio-pilot/lib/charms/istio_pilot/v0/istio_gateway_info.py
+++ b/charms/istio-pilot/lib/charms/istio_pilot/v0/istio_gateway_info.py
@@ -156,6 +156,7 @@ class GatewayRequirer(Object):
         Raises:
             GatewayRelationDataMissingError: if data is missing or incomplete
             GatewayRelationMissingError: if there is no related application
+            ops.model.TooManyRelatedAppsError: if there is more than one related application
         """
         # Raise if there is no related applicaton
         if not relation:

--- a/charms/istio-pilot/lib/charms/istio_pilot/v0/istio_gateway_info.py
+++ b/charms/istio-pilot/lib/charms/istio_pilot/v0/istio_gateway_info.py
@@ -78,7 +78,7 @@ class ProviderCharm(self):
 The data shared by this library has only two items:
 
 * gateway_name: the name of the Gateway the provider knows about. It corresponds to
-the `name` field in the Gateway definition:
+the `name` field in the Gateway definition. In the following example `gateway_name` value will be equal to `my-gateway`
 
 ```yaml
 apiVersion: networking.istio.io/v1alpha3

--- a/charms/istio-pilot/lib/charms/istio_pilot/v0/istio_gateway_info.py
+++ b/charms/istio-pilot/lib/charms/istio_pilot/v0/istio_gateway_info.py
@@ -54,7 +54,6 @@ Class RequirerCharm(CharmBase):
 provides:
   gateway-info:
     interface: istio-gateway-info
-    limit: 1
 ```
 
 ### Instantiate the GatewayProvider class in charm.py
@@ -133,7 +132,8 @@ class GatewayRequirer(Object):
         self.requirer_charm = requirer_charm
         self.relation_name = relation_name
 
-    def _relation_preflight_checks(self, relation: Relation) -> None:
+    @staticmethod
+    def _relation_preflight_checks(relation: Relation) -> None:
         """Series of checks for the relation and relation data.
         Args:
             relation (Relation): the relation object to run the checks on
@@ -206,16 +206,17 @@ class GatewayProvider(Object):
             gateway_namespace(str): the namespace of the Gateway the provider knows about
         """
         # Update the relation data bag with localgateway information
-        relation = self.model.get_relation(self.relation_name)
+        relations = self.model.relations[self.relation_name]
 
         # Raise if there is no related applicaton
-        if not relation:
+        if not relations:
             raise GatewayRelationMissingError()
 
         # Update relation data
-        relation.data[self.provider_charm.app].update(
-            {
-                "gateway_name": gateway_name,
-                "gateway_namespace": gateway_namespace,
-            }
-        )
+        for relation in relations:
+            relation.data[self.provider_charm.app].update(
+                {
+                    "gateway_name": gateway_name,
+                    "gateway_namespace": gateway_namespace,
+                }
+            )

--- a/charms/istio-pilot/lib/charms/istio_pilot/v0/istio_gateway_info.py
+++ b/charms/istio-pilot/lib/charms/istio_pilot/v0/istio_gateway_info.py
@@ -186,6 +186,7 @@ class GatewayRequirer(Object):
             GatewayRelationMissingError: if there is no related application
         """
         # Run pre-flight checks
+        # Raises TooManyRelatedAppsError if related to more than one app
         relation = self.model.get_relation(self.relation_name)
         self._relation_preflight_checks(relation=relation)
 

--- a/charms/istio-pilot/lib/charms/istio_pilot/v0/istio_gateway_info.py
+++ b/charms/istio-pilot/lib/charms/istio_pilot/v0/istio_gateway_info.py
@@ -72,6 +72,22 @@ class ProviderCharm(self):
         except GatewayRelationError as error:
             raise <your preferred exception with a message> from error
 ```
+
+## Relation data
+
+The data shared by this library has only two items:
+
+* gateway_name: the name of the Gateway the provider knows about. It corresponds to
+the `name` field in the Gateway definition:
+
+```yaml
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: my-gateway
+```
+
+* gateway_namespace: the namespace where the Gateway is deployed.
 """
 
 import logging

--- a/charms/istio-pilot/lib/charms/istio_pilot/v0/istio_gateway_info.py
+++ b/charms/istio-pilot/lib/charms/istio_pilot/v0/istio_gateway_info.py
@@ -1,46 +1,84 @@
-"""Library for sharing istio gateway information
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
 
-This library wraps the relation endpoints using the `istio-gateway-name`
-interface. It provides a Python API for both requesting and providing 
-gateway information.
+"""Library for sharing Istio Gateway(s) information
 
+This library offers a Python API for providing and requesting information about
+Istio Gateway(s) by wrapping the `gateway-info` relation endpoints.
+The default relation name is `gateway-info` and it's recommended to use that name,
+though if changed, you must ensure to pass the correct name when instantiating the
+provider and requirer classes, as well as in metadata.yaml.
+ 
 ## Getting Started
 
-### Fetch library with charmcraft
-You can fetch the library using the following commands with charmcraft.
+### Fetching the library with charmcraft
+
+Using charmcraft you can:
 ```shell
-cd some-charm
 charmcraft fetch-lib charms.istio_pilot.v0.istio_gateway_info
 ```
+
+## Using the library as requirer
+
 ### Add relation to metadata.yaml
 ```yaml
 requires:
-    gateway-info:
-        interface: istio_gateway_info
-        limit: 1
+  gateway-info:
+    interface: istio-gateway-info
+    limit: 1
 ```
 
-### Initialise the library in charm.py
-```python
-from charms.istio_pilot.v0.istio_gateway_info import GatewayProvider, GatewayRelationError
+### Instantiate the GatewayRequirer class in charm.py
 
-Class SomeCharm(CharmBase):
+```python
+from charms.istio_pilot.v0.istio_gateway_info import GatewayRequirer, GatewayRelationError
+
+Class RequirerCharm(CharmBase):
     def __init__(self, *args):
-        self.gateway = GatewayProvider(self)
+        self.gateway = GatewayRequirer(self)
         self.framework.observe(self.on.some_event_emitted, self.some_event_function)
 
     def some_event_function():
         # use the getter function wherever the info is needed
         try:
             gateway_data = self.gateway_relation.get_relation_data()
-            except GatewayRelationError as error:
-            ...
+        except GatewayRelationError as error:
+            raise <your preferred exception> from error
+```
+
+## Using the library as provider
+
+### Add relation to metadata.yaml
+```yaml
+provides:
+  gateway-info:
+    interface: istio-gateway-info
+    limit: 1
+```
+
+### Instantiate the GatewayProvider class in charm.py
+
+```python
+from charms.istio_pilot.v0.istio_gateway_info import GatewayProvider, GatewayRelationError
+class ProviderCharm(self):
+    def __init__(self, *args, **kwargs):
+        ...
+        self.gateway_provider = GatewayProvider(self)
+        self.observe(self.on.some_event, self._some_event_handler)
+    def _some_event_handler(self, ...):
+        # This will update the relation data bag with the Gateway name and namespace
+        try:
+            self.gateway_provider.send_gateway_data(charm, gateway_name, gateway_namespace)
+        except GatewayRelationError as error:
+            raise <your preferred exception with a message> from error
 ```
 """
 
 import logging
 from ops.framework import Object
-from ops.model import Application
+from ops.model import Model, Relation
+from ops.charm import CharmBase
 
 # The unique Charmhub library identifier, never change it
 LIBID = "354103422e7a43e2870e4203fbb5a649"
@@ -50,11 +88,12 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
-
-RELATION_NAME = "gateway-info"
-INTERFACE_NAME = "istio-gateway-info"
+# Default relation and interface names. If changed, consistency must be kept
+# across the provider and requirer.
+DEFAULT_RELATION_NAME = "gateway-info"
+DEFAULT_INTERFACE_NAME = "istio-gateway-info"
 
 logger = logging.getLogger(__name__)
 
@@ -65,13 +104,7 @@ class GatewayRelationError(Exception):
 
 class GatewayRelationMissingError(GatewayRelationError):
     def __init__(self):
-        self.message = "Missing gateway-info relation with istio-pilot"
-        super().__init__(self.message)
-
-
-class GatewayRelationTooManyError(GatewayRelationError):
-    def __init__(self):
-        self.message = "Too many istio-gateway-info relations"
+        self.message = "Missing gateway-info relation."
         super().__init__(self.message)
 
 
@@ -82,44 +115,107 @@ class GatewayRelationDataMissingError(GatewayRelationError):
 
 
 class GatewayRequirer(Object):
-    def __init__(self, charm, relation_name: str = RELATION_NAME):
-        super().__init__(charm, relation_name)
-        self.charm = charm
+    """Base class that represents a requirer relation end.
+
+    Args:
+        requirer_charm (CharmBase): the requirer application
+        relation_name (str, optional): the name of the relation
+
+    Attributes:
+        requirer_charm (CharmBase): variable for storing the requirer application
+        relation_name (str): variable for storing the name of the relation
+    """
+
+    def __init__(self, requirer_charm, relation_name: str = DEFAULT_RELATION_NAME):
+        super().__init__(requirer_charm, relation_name)
+        # TODO: remove this attribute, we are not really using it at all.
+        # Leaving it to keep backwards compatibility.
+        self.requirer_charm = requirer_charm
         self.relation_name = relation_name
 
-    def get_relation_data(self):
-        if not self.model.unit.is_leader():
-            return
-        gateway = self.model.relations[self.relation_name]
-        if len(gateway) == 0:
+    def _relation_preflight_checks(self, relation: Relation) -> None:
+        """Series of checks for the relation and relation data.
+        Args:
+            relation (Relation): the relation object to run the checks on
+        Raises:
+            GatewayRelationDataMissingError: if data is missing or incomplete
+            GatewayRelationMissingError: if there is no related application
+        """
+        # Raise if there is no related applicaton
+        if not relation:
             raise GatewayRelationMissingError()
-        if len(gateway) > 1:
-            raise GatewayRelationTooManyError()
 
-        remote_app = [
-            app
-            for app in gateway[0].data.keys()
-            if isinstance(app, Application) and not app._is_our_app
-        ][0]
+        # Extract remote app information from relation
+        remote_app = relation.app
+        # Get relation data from remote app
+        relation_data = relation.data[remote_app]
 
-        data = gateway[0].data[remote_app]
+        # Raise if there is no data found in the relation data bag
+        if not relation_data:
+            raise GatewayRelationDataMissingError("No data found in relation data bag.")
 
-        if not "gateway_name" in data:
-            logger.error(
-                "Missing gateway name in gateway-info relation data. Waiting for gateway creation in istio-pilot"
-            )
-            raise GatewayRelationDataMissingError(
-                "Missing gateway name in gateway-info relation data. Waiting for gateway creation in istio-pilot"
-            )
+        # Check if the relation data contains the expected attributes
+        expected_attributes = ["gateway_name", "gateway_namespace"]
+        missing_attributes = [
+            attribute for attribute in expected_attributes if attribute not in relation_data
+        ]
+        if missing_attributes:
+            raise GatewayRelationDataMissingError(f"Missing attributes: {missing_attributes}")
 
-        if not "gateway_namespace" in data:
-            logger.error("Missing gateway namespace in gateway-info relation data")
-            raise GatewayRelationDataMissingError(
-                "Missing gateway namespace in gateway-info relation data"
-            )
+    def get_relation_data(self) -> dict:
+        """Returns a dictionary with the Gateway information.
+
+        Raises:
+            GatewayRelationDataMissingError: if data is missing entirely or some attributes
+            GatewayRelationMissingError: if there is no related application
+        """
+        # Run pre-flight checks
+        relation = self.model.get_relation(self.relation_name)
+        self._relation_preflight_checks(relation=relation)
+
+        # Get relation data from remote app
+        relation_data = relation.data[relation.app]
 
         return {
-            "gateway_name": data["gateway_name"],
-            "gateway_namespace": data["gateway_namespace"],
+            "gateway_name": relation_data["gateway_name"],
+            "gateway_namespace": relation_data["gateway_namespace"],
         }
 
+
+class GatewayProvider(Object):
+    """Base class that represents a provider relation end.
+
+    Args:
+        provider_charm (CharmBase): the provider application
+        relation_name (str, optional): the name of the relation
+
+    Attributes:
+        provider_charm (CharmBase): variable for storing the provider application
+        relation_name (str): variable for storing the name of the relation
+    """
+
+    def __init__(self, provider_charm, relation_name: str = DEFAULT_RELATION_NAME):
+        super().__init__(provider_charm, relation_name)
+        self.provider_charm = provider_charm
+        self.relation_name = relation_name
+
+    def send_gateway_relation_data(self, gateway_name: str, gateway_namespace: str) -> None:
+        """Updates the relation data bag with data from the localGateway.
+        Args:
+            gateway_name (str): the name of the Gateway the provider knows about
+            gateway_namespace(str): the namespace of the Gateway the provider knows about
+        """
+        # Update the relation data bag with localgateway information
+        relation = self.model.get_relation(self.relation_name)
+
+        # Raise if there is no related applicaton
+        if not relation:
+            raise GatewayRelationMissingError()
+
+        # Update relation data
+        relation.data[self.provider_charm.app].update(
+            {
+                "gateway_name": gateway_name,
+                "gateway_namespace": gateway_namespace,
+            }
+        )

--- a/charms/istio-pilot/tests/unit/test_gateway_info.py
+++ b/charms/istio-pilot/tests/unit/test_gateway_info.py
@@ -152,6 +152,7 @@ def test_send_relation_data_passes(provider_charm_harness):
     provider_charm_harness.begin()
     provider_charm_harness.set_leader(True)
     relation_id = provider_charm_harness.add_relation(TEST_RELATION_NAME, "app")
+    provider_charm_harness.add_relation(TEST_RELATION_NAME, "app")
 
     # Instantiate GatewayProvider class
     provider_charm_harness.charm.gateway_provider = GatewayProvider(
@@ -165,10 +166,11 @@ def test_send_relation_data_passes(provider_charm_harness):
     provider_charm_harness.charm.gateway_provider.send_gateway_relation_data(
         gateway_name="test-gateway", gateway_namespace="test"
     )
-    relation = provider_charm_harness.model.get_relation(TEST_RELATION_NAME)
-    actual_relation_data = relation.data[provider_charm_harness.charm.app]
-    # Assert returns dictionary with expected values
-    assert actual_relation_data == expected_relation_data
+    relations = provider_charm_harness.model.relations[TEST_RELATION_NAME]
+    for relation in relations:
+        actual_relation_data = relation.data[provider_charm_harness.charm.app]
+        # Assert returns dictionary with expected values
+        assert actual_relation_data == expected_relation_data
 
 
 def test_provider_raise_no_relation(provider_charm_harness):

--- a/charms/istio-pilot/tests/unit/test_gateway_info.py
+++ b/charms/istio-pilot/tests/unit/test_gateway_info.py
@@ -3,14 +3,29 @@
 # See LICENSE file for licensing details.
 
 import pytest
-from charms.istio_pilot.v0.istio_gateway_info import GatewayRequirer
+from charms.istio_pilot.v0.istio_gateway_info import (
+    GatewayProvider,
+    GatewayRelationDataMissingError,
+    GatewayRelationMissingError,
+    GatewayRequirer,
+)
 from ops.charm import CharmBase
+from ops.model import TooManyRelatedAppsError
 from ops.testing import Harness
 
-REQUIRER_CHARM_META = """
-name: test-charm
+DEFAULT_RELATION_NAME = "gateway-info"
+DEFAULT_INTERFACE_NAME = "istio-gateway-info"
+TEST_RELATION_NAME = "test-relation"
+REQUIRER_CHARM_META = f"""
+name: requirer-test-charm
 requires:
-  test-relation:
+  {TEST_RELATION_NAME}:
+    interface: test-interface
+"""
+PROVIDER_CHARM_META = f"""
+name: provider-test-charm
+provides:
+  {TEST_RELATION_NAME}:
     interface: test-interface
 """
 
@@ -24,17 +39,22 @@ def requirer_charm_harness():
     return Harness(GenericCharm, meta=REQUIRER_CHARM_META)
 
 
-def test_get_relation_data_passes(requirer_charm_harness, mocker):
+@pytest.fixture()
+def provider_charm_harness():
+    return Harness(GenericCharm, meta=PROVIDER_CHARM_META)
+
+
+def test_get_relation_data_passes(requirer_charm_harness):
     """Assert the relation data is as expected."""
     # Initial configuration
     requirer_charm_harness.set_model_name("test-model")
     requirer_charm_harness.begin()
     requirer_charm_harness.set_leader(True)
-    relation_id = requirer_charm_harness.add_relation("test-relation", "app")
+    relation_id = requirer_charm_harness.add_relation(TEST_RELATION_NAME, "app")
 
     # Instantiate GatewayRequirer class
     requirer_charm_harness.charm.gateway_requirer = GatewayRequirer(
-        requirer_charm_harness.charm, relation_name="test-relation"
+        requirer_charm_harness.charm, relation_name=TEST_RELATION_NAME
     )
 
     # Add and update relation
@@ -47,3 +67,122 @@ def test_get_relation_data_passes(requirer_charm_harness, mocker):
 
     # Assert returns dictionary with expected values
     assert actual_relation_data == expected_relation_data
+
+
+def test_check_raise_too_many_relations(requirer_charm_harness):
+    """Assert that TooManyRelatedAppsError is raised if more than one application is related."""
+    requirer_charm_harness.set_model_name("test-model")
+    requirer_charm_harness.begin()
+    requirer_charm_harness.set_leader(True)
+
+    # Instantiate GatewayRequirer class
+    requirer_charm_harness.charm.gateway_requirer = GatewayRequirer(
+        requirer_charm_harness.charm, relation_name=TEST_RELATION_NAME
+    )
+
+    requirer_charm_harness.add_relation(TEST_RELATION_NAME, "app")
+    requirer_charm_harness.add_relation(TEST_RELATION_NAME, "app2")
+
+    with pytest.raises(TooManyRelatedAppsError):
+        requirer_charm_harness.charm.gateway_requirer.get_relation_data()
+
+
+def test_preflight_checks_raise_no_relation(requirer_charm_harness):
+    """Assert that GatewayRelationMissingError is raised in the absence of the relation."""
+    requirer_charm_harness.set_model_name("test-model")
+    requirer_charm_harness.begin()
+    requirer_charm_harness.set_leader(True)
+
+    # Instantiate GatewayRequirer class
+    requirer_charm_harness.charm.gateway_requirer = GatewayRequirer(
+        requirer_charm_harness.charm, relation_name=TEST_RELATION_NAME
+    )
+
+    with pytest.raises(GatewayRelationMissingError):
+        requirer_charm_harness.charm.gateway_requirer.get_relation_data()
+
+
+def test_preflight_checks_raise_no_relation_data(requirer_charm_harness):
+    """Assert that GatewayRelationDataMissingError is raised in the absence of relation data."""
+    requirer_charm_harness.set_model_name("test-model")
+    requirer_charm_harness.begin()
+    requirer_charm_harness.set_leader(True)
+
+    # Instantiate GatewayRequirer class
+    requirer_charm_harness.charm.gateway_requirer = GatewayRequirer(
+        requirer_charm_harness.charm, relation_name=TEST_RELATION_NAME
+    )
+
+    requirer_charm_harness.add_relation(TEST_RELATION_NAME, "app")
+
+    with pytest.raises(GatewayRelationDataMissingError) as error:
+        requirer_charm_harness.charm.gateway_requirer.get_relation_data()
+    assert str(error.value) == "No data found in relation data bag."
+
+
+def test_preflight_checks_raises_data_missing_attribute(requirer_charm_harness):
+    """Assert that GatewayRelationDataMissingError is raised when
+    the relation data bag missing an expected attribute.
+    """
+    # Initial configuration
+    requirer_charm_harness.set_model_name("test-model")
+    requirer_charm_harness.begin()
+    requirer_charm_harness.set_leader(True)
+    relation_id = requirer_charm_harness.add_relation(TEST_RELATION_NAME, "app")
+
+    # Instantiate GatewayRequirer class
+    requirer_charm_harness.charm.gateway_requirer = GatewayRequirer(
+        requirer_charm_harness.charm, relation_name=TEST_RELATION_NAME
+    )
+
+    # Add and update relation
+    faulty_relation_data = {"gateway_name": "name"}
+    requirer_charm_harness.add_relation_unit(relation_id, "app/0")
+    requirer_charm_harness.update_relation_data(relation_id, "app", faulty_relation_data)
+
+    with pytest.raises(GatewayRelationDataMissingError) as error:
+        requirer_charm_harness.charm.gateway_requirer.get_relation_data()
+    assert str(error.value) == "Missing attributes: ['gateway_namespace']"
+
+
+def test_send_relation_data_passes(provider_charm_harness):
+    """Assert the relation data is as expected."""
+    # Initial configuration
+    provider_charm_harness.set_model_name("test-model")
+    provider_charm_harness.begin()
+    provider_charm_harness.set_leader(True)
+    relation_id = provider_charm_harness.add_relation(TEST_RELATION_NAME, "app")
+
+    # Instantiate GatewayProvider class
+    provider_charm_harness.charm.gateway_provider = GatewayProvider(
+        provider_charm_harness.charm, relation_name=TEST_RELATION_NAME
+    )
+
+    # Add and update relation
+    expected_relation_data = {"gateway_name": "test-gateway", "gateway_namespace": "test"}
+    provider_charm_harness.add_relation_unit(relation_id, "app/0")
+
+    provider_charm_harness.charm.gateway_provider.send_gateway_relation_data(
+        gateway_name="test-gateway", gateway_namespace="test"
+    )
+    relation = provider_charm_harness.model.get_relation(TEST_RELATION_NAME)
+    actual_relation_data = relation.data[provider_charm_harness.charm.app]
+    # Assert returns dictionary with expected values
+    assert actual_relation_data == expected_relation_data
+
+
+def test_provider_raise_no_relation(provider_charm_harness):
+    """Assert that GatewayRelationMissingError is raised in the absence of the relation."""
+    provider_charm_harness.set_model_name("test-model")
+    provider_charm_harness.begin()
+    provider_charm_harness.set_leader(True)
+
+    # Instantiate GatewayProvider class
+    provider_charm_harness.charm.gateway_provider = GatewayProvider(
+        provider_charm_harness.charm, relation_name=TEST_RELATION_NAME
+    )
+
+    with pytest.raises(GatewayRelationMissingError):
+        provider_charm_harness.charm.gateway_provider.send_gateway_relation_data(
+            gateway_name="test-gateway", gateway_namespace="test"
+        )


### PR DESCRIPTION
This library can be used by other charms that can provide gateway information. The previous implementation of the library did not include the provider logic. This commit extends the API to be able to instantiate the provider class in other charms other than istio-pilot.

TODO:
- [x] Add unit tests 