### PR TITLE
feat: add Gateway reconciliation/removal features

### DIFF
--- a/charms/istio-pilot/requirements-unit.txt
+++ b/charms/istio-pilot/requirements-unit.txt
@@ -19,8 +19,8 @@ certifi==2022.12.7
     #   httpcore
     #   httpx
     #   requests
-charmed-kubeflow-chisme==0.0.8
-    # via -r requirements.txt
+charmed-kubeflow-chisme@git+https://github.com/canonical/charmed-kubeflow-chisme.git@0f8e4bac0b93395b5ae1102be65ee9b6d719326b
+    # via -r requirements.in
 charset-normalizer==3.1.0
     # via
     #   -r requirements.txt

--- a/charms/istio-pilot/requirements-unit.txt
+++ b/charms/istio-pilot/requirements-unit.txt
@@ -19,7 +19,7 @@ certifi==2022.12.7
     #   httpcore
     #   httpx
     #   requests
-charmed-kubeflow-chisme@git+https://github.com/canonical/charmed-kubeflow-chisme.git@0f8e4bac0b93395b5ae1102be65ee9b6d719326b
+charmed-kubeflow-chisme@git+https://github.com/canonical/charmed-kubeflow-chisme.git@29a30ce7f9c64f9ebdb06d39ab395fc668fb6c47
     # via -r requirements.in
 charset-normalizer==3.1.0
     # via

--- a/charms/istio-pilot/requirements.in
+++ b/charms/istio-pilot/requirements.in
@@ -1,4 +1,6 @@
-charmed-kubeflow-chisme
+# TODO: Remove this when updated KRH is committed to chisme and used here
+# charmed-kubeflow-chisme
+git+https://github.com/canonical/charmed-kubeflow-chisme.git@0f8e4bac0b93395b5ae1102be65ee9b6d719326b
 jinja2
 lightkube
 oci-image

--- a/charms/istio-pilot/requirements.in
+++ b/charms/istio-pilot/requirements.in
@@ -1,6 +1,6 @@
 # TODO: Remove this when updated KRH is committed to chisme and used here
 # charmed-kubeflow-chisme
-git+https://github.com/canonical/charmed-kubeflow-chisme.git@0f8e4bac0b93395b5ae1102be65ee9b6d719326b
+git+https://github.com/canonical/charmed-kubeflow-chisme.git@29a30ce7f9c64f9ebdb06d39ab395fc668fb6c47
 jinja2
 lightkube
 oci-image

--- a/charms/istio-pilot/requirements.txt
+++ b/charms/istio-pilot/requirements.txt
@@ -13,7 +13,7 @@ certifi==2022.12.7
     #   httpcore
     #   httpx
     #   requests
-charmed-kubeflow-chisme@git+https://github.com/canonical/charmed-kubeflow-chisme.git@0f8e4bac0b93395b5ae1102be65ee9b6d719326b
+charmed-kubeflow-chisme@git+https://github.com/canonical/charmed-kubeflow-chisme.git@29a30ce7f9c64f9ebdb06d39ab395fc668fb6c47
     # via -r requirements.in
 charset-normalizer==3.1.0
     # via requests

--- a/charms/istio-pilot/requirements.txt
+++ b/charms/istio-pilot/requirements.txt
@@ -13,7 +13,7 @@ certifi==2022.12.7
     #   httpcore
     #   httpx
     #   requests
-charmed-kubeflow-chisme==0.0.8
+charmed-kubeflow-chisme@git+https://github.com/canonical/charmed-kubeflow-chisme.git@0f8e4bac0b93395b5ae1102be65ee9b6d719326b
     # via -r requirements.in
 charset-normalizer==3.1.0
     # via requests
@@ -29,9 +29,6 @@ idna==3.4
     # via
     #   anyio
     #   requests
-    #   rfc3986
-importlib-resources==5.12.0
-    # via jsonschema
 jinja2==3.1.2
     # via
     #   -r requirements.in
@@ -57,8 +54,6 @@ ordered-set==4.1.0
     # via deepdiff
 packaging==23.0
     # via -r requirements.in
-pkgutil-resolve-name==1.3.10
-    # via jsonschema
 pyrsistent==0.19.3
     # via jsonschema
 pyyaml==6.0
@@ -70,8 +65,6 @@ requests==2.28.2
     # via
     #   -r requirements.in
     #   serialized-data-interface
-rfc3986[idna2008]==1.5.0
-    # via httpx
 ruamel-yaml==0.17.21
     # via charmed-kubeflow-chisme
 ruamel-yaml-clib==0.2.7
@@ -87,5 +80,3 @@ tenacity==8.2.2
     # via -r requirements.in
 urllib3==1.26.15
     # via requests
-zipp==3.15.0
-    # via importlib-resources

--- a/charms/istio-pilot/src/manifests/gateway.yaml.j2
+++ b/charms/istio-pilot/src/manifests/gateway.yaml.j2
@@ -2,27 +2,37 @@
 apiVersion: networking.istio.io/v1beta1
 kind: Gateway
 metadata:
-  name: {{ name }}
-  namespace: {{ model_name }}
-  labels:
-    app.{{ app_name }}.io/is-workload-entity: "true"
+  name: {{ gateway_name }}
+  namespace: {{ namespace }}
 spec:
   selector:
     istio: ingressgateway
   servers:
   - hosts:
     - '*'
-{% if not secret_name %}
+{% if not secure %}
     port:
       name: http
-      number: {{ gateway_http_port }}
+      number: {{ port }}
       protocol: HTTP
 {% else %}
     port:
       name: https
-      number: {{ gateway_https_port }}
+      number: {{ port }}
       protocol: HTTPS
     tls:
       mode: SIMPLE
-      credentialName: {{ secret_name }}
+      credentialName: {{ gateway_name }}-gateway-secret
+{% endif %}
+---
+{% if secure %}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ gateway_name }}-gateway-secret
+  namespace: {{ namespace }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ ssl_crt }}
+  tls.key: {{ ssl_key }}
 {% endif %}

--- a/charms/istio-pilot/tests/unit/test_charm.py
+++ b/charms/istio-pilot/tests/unit/test_charm.py
@@ -322,7 +322,9 @@ class TestCharmHelpers:
 
         mocked_remove_envoyfilter.assert_called_once()
 
-    def test_remove_gateway(self, harness, kubernetes_resource_handler_with_client_and_existing_gateway):
+    def test_remove_gateway(
+        self, harness, kubernetes_resource_handler_with_client_and_existing_gateway
+    ):
         """Tests that _remove_gateway works when expected.
 
         Uses the kubernetes_resource_handler_with_client_and_existing_gateway pre-made
@@ -349,7 +351,6 @@ class TestCharmHelpers:
 
         # Assert that we tried to remove the old gateway
         assert mocked_lightkube_client.delete.call_args.kwargs["name"] == existing_gateway_name
-
 
     @patch("charm.Client", return_value=MagicMock())
     def test_remove_envoyfilter(self, mocked_lightkube_client_class):


### PR DESCRIPTION
Adds:
* _reconcile_gateway
* _remove_gateway
* helpers to support these
* unit tests to test everything added

Note that this temporarily uses a version of charmed-kubeflow-chisme pulled from a specific commit in github.  This is required to enable KubernetesResourceHandler.reconcile() and .delete() features.  This will be removed when the updated KRH is approved and merged.