### PR TITLE
feat: add ingress relation handler to istio-pilot event handling refactor

### DIFF
--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -845,6 +845,7 @@ def _wait_for_update_rollout(
 def get_routes_from_ingress_interface(
     ingress_interface: Optional[dict], this_app: Application
 ) -> dict:
+    """Returns a dict of route data from the ingress interface."""
     routes = {}
 
     if ingress_interface:

--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -842,7 +842,9 @@ def _wait_for_update_rollout(
     return versions
 
 
-def get_routes_from_ingress_interface(ingress_interface: Optional[dict], this_app: Application) -> dict:
+def get_routes_from_ingress_interface(
+    ingress_interface: Optional[dict], this_app: Application
+) -> dict:
     routes = {}
 
     if ingress_interface:

--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -2,7 +2,7 @@
 
 import logging
 import subprocess
-from typing import Optional
+from typing import List, Optional
 
 import tenacity
 from charmed_kubeflow_chisme.exceptions import ErrorWithStatus, GenericCharmRuntimeError
@@ -515,7 +515,7 @@ class Operator(CharmBase):
         )
         krh.reconcile()
 
-    def _reconcile_ingress(self, routes: list[dict]):
+    def _reconcile_ingress(self, routes: List[dict]):
         """Reconcile all Ingress relations, managing the VirtualService resources.
 
         Args:

--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -17,7 +17,7 @@ from lightkube.resources.admissionregistration_v1 import ValidatingWebhookConfig
 from lightkube.resources.core_v1 import Secret, Service
 from ops.charm import CharmBase, RelationBrokenEvent
 from ops.main import main
-from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
+from ops.model import ActiveStatus, Application, BlockedStatus, MaintenanceStatus, WaitingStatus
 from packaging.version import Version
 from serialized_data_interface import (
     NoCompatibleVersions,
@@ -425,23 +425,13 @@ class Operator(CharmBase):
         except NoCompatibleVersions as err:
             raise ErrorWithStatus(err, BlockedStatus)
 
-        # Filter out data we sent out.
-        if ingress_interface:
-            routes = {
-                (rel, app): route
-                for (rel, app), route in sorted(
-                    ingress_interface.get_data().items(), key=lambda tup: tup[0][0].id
-                )
-                if app != self.app
-            }
-        else:
-            # If there is no ingress-auth relation, we have no data here
-            routes = {}
+        # Get all route data from the ingress interface
+        routes = get_routes_from_ingress_interface(ingress_interface, self.app)
 
+        # The app-level data is still visible on a broken relation, but we
+        # shouldn't be keeping the VirtualService for that related app.
         if isinstance(event, RelationBrokenEvent):
-            # The app-level data is still visible on a broken relation, but we
-            # shouldn't be keeping the VirtualService for that related app.
-            del routes[(event.relation, event.app)]
+            routes.pop((event.relation, event.app))
 
         return routes
 
@@ -850,6 +840,24 @@ def _wait_for_update_rollout(
                     f" version - upgrade rollout complete"
                 )
     return versions
+
+
+def get_routes_from_ingress_interface(ingress_interface: Optional[dict], this_app: Application) -> dict:
+    routes = {}
+
+    if ingress_interface:
+        sorted_interface_data = sorted(
+            ingress_interface.get_data().items(), key=lambda tup: tup[0][0].id
+        )
+
+        for (rel, app), route in sorted_interface_data:
+            if app != this_app:
+                routes[(rel, app)] = route
+    else:
+        # If there is no ingress-auth relation, we have no data here
+        pass
+
+    return routes
 
 
 def _xor(a, b):

--- a/charms/istio-pilot/src/manifests/virtual_service.yaml.j2
+++ b/charms/istio-pilot/src/manifests/virtual_service.yaml.j2
@@ -1,23 +1,24 @@
+{% for route in routes %}
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
-  name: {{ service }}
-  labels:
-    app.{{ app_name }}.io/is-workload-entity: "true"
+  name: {{ route["service"] }}
+  namespace: {{ charm_namespace }}
 spec:
   gateways:
-  - '{{ namespace }}/{{ gateway }}'
+  - '{{ gateway_namespace }}/{{ gateway_name }}'
   hosts:
   - '*'
   http:
   - match:
     - uri:
-        prefix: '{{ prefix }}'
+        prefix: '{{ route["prefix"] }}'
     rewrite:
-      uri: '{{ rewrite or prefix }}'
+      uri: '{{ route["rewrite"] or route["prefix"] }}'
     route:
     - destination:
-        host: '{{ service }}.{{ namespace }}.svc.cluster.local'
+        host: '{{ route["service"] }}.{{ route["namespace"] }}.svc.cluster.local'
         port:
-          number: {{ port }}
+          number: {{ route["port"] }}
+{% endfor %}


### PR DESCRIPTION
This is based on #243. Recommended that this be reviewed after #243 is merged as that accounts for some of the deltas. This is part of a larger effort to refactor istio-pilot's event handling, as described [in jira](https://warthogs.atlassian.net/browse/KF-728). This merges into a feature branch and covers only part of the total effort.

* adds _get_ingress_data() to pulls route data from ingress relations
* adds _reconcile_ingress() to update, modify, and delete ingresses based on the related applications
* refactors the virtual_service.yaml.j2
* refactors gateway name/namespace handling into properties to make it shared between gateway and ingress handling
* adds unit tests for above new functions