### PR TITLE
fix: publishing CI in istio-pilot event handler feature branch

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -58,7 +58,7 @@ jobs:
           ref: ${{ inputs.source_branch }}
 
       - name: Select charmhub channel
-        uses: canonical/charming-actions/channel@2.2.2
+        uses: canonical/charming-actions/channel@2.2.5
         id: select-channel
         if: ${{ inputs.destination_channel == '' }}
 
@@ -84,7 +84,7 @@ jobs:
           echo "::set-output name=tag_prefix::$tag_prefix"
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@2.2.2
+        uses: canonical/charming-actions/upload-charm@2.2.5
         with:
           credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Release charm to channel
-        uses: canonical/charming-actions/release-charm@2.2.2
+        uses: canonical/charming-actions/release-charm@2.2.5
         with:
           credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Cherry picks a bump in the charming-actions version from main.  This is to fix the publishing CI in the feature branch