### PR TITLE
fix: istio-pilot's handling of incomplete Gateway Services

### DIFF
--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -664,7 +664,7 @@ class Operator(CharmBase):
             )
             self._log_and_set_status(status_to_publish)
             for i, error in enumerate(errors):
-                self.log.info(f"Handled error {i}/{len(errors)}: {error.status}")
+                self.log.info(f"Handled error {i+1}/{len(errors)}: {error.status}")
         else:
             self.unit.status = ActiveStatus()
 

--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -236,6 +236,12 @@ class Operator(CharmBase):
             handled_errors.append(err)
 
         try:
+            # If Gateway Service is not ready, notify user
+            self._assert_gateway_service_status()
+        except ErrorWithStatus as err:
+            handled_errors.append(err)
+
+        try:
             self._send_gateway_info()
         except ErrorWithStatus as err:
             handled_errors.append(err)
@@ -359,6 +365,17 @@ class Operator(CharmBase):
 
         self.log.info("Upgrade complete.")
         self.unit.status = ActiveStatus()
+
+    def _assert_gateway_service_status(self):
+        """Checks if the ingress gateway service is up, raising an ErrorWithStatus if it is not."""
+        if not self._is_gateway_service_up:
+            raise ErrorWithStatus(
+                f"Gateway Service '{self.model.config['gateway-service-name']}"
+                f" in namespace {self.model.name} is missing or does not have an"
+                f" external IP.  If this persists, there may be a problem with"
+                f" the Service.",
+                WaitingStatus,
+            )
 
     def _check_leader(self):
         """Check if this unit is a leader."""
@@ -828,7 +845,7 @@ def _get_address_from_loadbalancer(svc):
         return None
 
     if len(ingresses) != 1:
-            raise ValueError("Unknown situation - LoadBalancer service has more than one ingress")
+        raise ValueError("Unknown situation - LoadBalancer service has more than one ingress")
 
     ingress = svc.status.loadBalancer.ingress[0]
     if getattr(ingress, "hostname", None) is not None:

--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -822,10 +822,12 @@ def _get_address_from_loadbalancer(svc):
           (str): The hostname or IP address of the LoadBalancer service
     """
     ingresses = svc.status.loadBalancer.ingress
+
+    # May happen due to the Kubernetes cluster not having a LoadBalancer provider
+    if ingresses is None or len(ingresses) == 0:
+        return None
+
     if len(ingresses) != 1:
-        if len(ingresses) == 0:
-            return None
-        else:
             raise ValueError("Unknown situation - LoadBalancer service has more than one ingress")
 
     ingress = svc.status.loadBalancer.ingress[0]

--- a/charms/istio-pilot/tests/unit/test_charm.py
+++ b/charms/istio-pilot/tests/unit/test_charm.py
@@ -486,6 +486,7 @@ class TestCharmHelpers:
             ("mock_loadbalancer_ip_service", True),
             ("mock_loadbalancer_hostname_service_not_ready", False),
             ("mock_loadbalancer_ip_service_not_ready", False),
+            ("mock_loadbalancer_ip_service_missing", False),
         ],
     )
     def test_is_gateway_service_up(self, mock_service_fixture, is_gateway_up, harness, request):
@@ -1279,6 +1280,20 @@ def mock_loadbalancer_ip_service_not_ready():
             "apiVersion": "v1",
             "kind": "Service",
             "status": {"loadBalancer": {"ingress": []}},
+            "spec": {"type": "LoadBalancer", "clusterIP": "10.10.10.10"},
+        }
+    )
+    return mock_nodeport_service
+
+
+@pytest.fixture()
+def mock_loadbalancer_ip_service_missing():
+    """This happens if LoadBalancer external IP is <pending> like if there is no provisioner."""
+    mock_nodeport_service = codecs.from_dict(
+        {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "status": {"loadBalancer": {}},
             "spec": {"type": "LoadBalancer", "clusterIP": "10.10.10.10"},
         }
     )


### PR DESCRIPTION
This improves the handling of a gateway LoadBalancer service that does not have any ingress IPs.  Previously, this could fail if the ingress attribute was None, such as when there is no LoadBalancer provider present in the cluster.

This also adds a check during reconcile which will raise an ErrorWithStatus when the Gateway Service is not ready.  