### PR TITLE
KF-3009 update k8s api version

### DIFF
--- a/charms/istio-gateway/src/manifest.yaml
+++ b/charms/istio-gateway/src/manifest.yaml
@@ -254,7 +254,7 @@ spec:
             optional: true
             secretName: istio-{{ kind }}gateway-workload-ca-certs
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:

--- a/charms/istio-gateway/tests/unit/data/egress-example.yaml
+++ b/charms/istio-gateway/tests/unit/data/egress-example.yaml
@@ -255,7 +255,7 @@ spec:
             optional: true
             secretName: istio-egressgateway-workload-ca-certs
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:

--- a/charms/istio-gateway/tests/unit/data/ingress-example.yaml
+++ b/charms/istio-gateway/tests/unit/data/ingress-example.yaml
@@ -255,7 +255,7 @@ spec:
             optional: true
             secretName: istio-ingressgateway-workload-ca-certs
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   labels:


### PR DESCRIPTION
change API version.
safe change since this is supported in K8s since 1.21

https://kubernetes.io/docs/reference/using-api/deprecation-guide/#poddisruptionbudget-v125


once updated on local charm within a bundle the resource can be successfully applied

![image](https://github.com/canonical/istio-operators/assets/51964909/7001024a-5746-418f-9ec5-d160818c5df9)
