### PR TITLE
Fix handling of SSL

### DIFF
--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -613,7 +613,7 @@ class Operator(CharmBase):
             "app_name": self.app.name,
             "envoyfilter_name": envoyfilter_name,
             "envoyfilter_namespace": self.model.name,
-            "gateway_port": self._gateway_port,
+            "gateway_ports": list(GATEWAY_PORTS.values()),
             "port": ingress_auth_data["port"],
             "request_headers": ingress_auth_data["allowed-request-headers"],
             "response_headers": ingress_auth_data["allowed-response-headers"],

--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -48,8 +48,10 @@ VIRTUAL_SERVICE_LIGHTKUBE_RESOURCE = create_namespaced_resource(
     plural="virtualservices",
 )
 
-GATEWAY_HTTP_PORT = 8080
-GATEWAY_HTTPS_PORT = 8443
+GATEWAY_PORTS = {
+    "http": 8080,
+    "https": 8443,
+}
 GATEWAY_TEMPLATE_FILES = ["src/manifests/gateway.yaml.j2"]
 KRH_GATEWAY_SCOPE = "gateway"
 METRICS_PORT = 15014
@@ -369,9 +371,9 @@ class Operator(CharmBase):
     @property
     def _gateway_port(self):
         if self._use_https():
-            return GATEWAY_HTTPS_PORT
+            return GATEWAY_PORTS["https"]
         else:
-            return GATEWAY_HTTP_PORT
+            return GATEWAY_PORTS["http"]
 
     def _get_interfaces(self):
         """Retrieve interface object."""

--- a/charms/istio-pilot/src/manifests/auth_filter.yaml.j2
+++ b/charms/istio-pilot/src/manifests/auth_filter.yaml.j2
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ envoyfilter_namespace }}
 spec:
   configPatches:
+  {% for gateway_port in gateway_ports %}
     - applyTo: HTTP_FILTER
       match:
         context: GATEWAY
@@ -39,6 +40,7 @@ spec:
                       {% for response_header in response_headers %}
                       - exact: {{ response_header }}
                       {% endfor %}
+  {% endfor %}
 
   workloadSelector:
     labels:

--- a/charms/istio-pilot/tests/unit/test_charm.py
+++ b/charms/istio-pilot/tests/unit/test_charm.py
@@ -30,8 +30,7 @@ from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingSta
 from ops.testing import Harness
 
 from charm import (
-    GATEWAY_HTTP_PORT,
-    GATEWAY_HTTPS_PORT,
+    GATEWAY_PORTS,
     Operator,
     _get_gateway_address_from_svc,
     _remove_envoyfilter,
@@ -435,8 +434,8 @@ class TestCharmHelpers:
     @pytest.mark.parametrize(
         "ssl_crt, ssl_key, expected_port, expected_context",
         [
-            ("", "", GATEWAY_HTTP_PORT, does_not_raise()),
-            ("x", "x", GATEWAY_HTTPS_PORT, does_not_raise()),
+            ("", "", GATEWAY_PORTS["http"], does_not_raise()),
+            ("x", "x", GATEWAY_PORTS["https"], does_not_raise()),
             ("x", "", None, pytest.raises(ErrorWithStatus)),
             ("", "x", None, pytest.raises(ErrorWithStatus)),
         ],

--- a/charms/istio-pilot/tests/unit/test_charm.py
+++ b/charms/istio-pilot/tests/unit/test_charm.py
@@ -1480,13 +1480,33 @@ def is_lightkube_resource_in_call_args_list(call_args_list, name, namespace=None
         namespace (str): The namespace of the lightkube resource to search for (will check
                          metadata.namespace)
     """
+    try:
+        get_lightkube_resource_in_call_args_list(call_args_list=call_args_list, name=name, namespace=namespace)
+        return True
+    except KeyError:
+        return False
+
+
+def get_lightkube_resource_in_call_args_list(call_args_list, name, namespace=None):
+    """Returns the first call_args from a call_args_list that was for a given lightkube resource.
+
+    Raises a KeyError if the object does not exist.
+
+    Args:
+        call_args_list (list): The list of call args to search, as given by a mock.call_args_list
+        name (str): The name of the lightkube resource to search for (will check metadata.name)
+        namespace (str): The namespace of the lightkube resource to search for (will check
+                         metadata.namespace)
+
+    Return: The lightkube resource
+    """
     for call_args in call_args_list:
         try:
             if (
-                call_args.kwargs["obj"].metadata.name == name
-                and getattr(call_args.kwargs["obj"].metadata, "namespace", None) == namespace
+                    call_args.kwargs["obj"].metadata.name == name
+                    and getattr(call_args.kwargs["obj"].metadata, "namespace", None) == namespace
             ):
-                return True
+                return call_args
         except Exception:
             continue
-    return False
+    raise KeyError(f"Resource {name} in namespace {namespace} not found in this call_args list.")


### PR DESCRIPTION
This PR updates the EnvoyFilter definition to always apply auth to both http and https traffic, regardless of which is currently enabled in the Gateway.  This is to prevent the possibility of these objects going out of sync (eg: Gateway allowing traffic on one port, and EnvoyFilter applying Auth on traffic through the other port), which could have occurred if the charm succeeded in updating one of those objects but failed to update the other (due to an error or incompatible settings).  By always applying the EnvoyFilter to all traffic, this possibility is prevented.

This PR came from an attempt to address https://github.com/canonical/bundle-kubeflow/issues/570, which showed our previously was misconfiguring the `EnvoyFilter` when using SSL.  It was reported that we incorrectly applied the `EnvoyFilter` only to http traffic and not https traffic.  Reproducing https://github.com/canonical/bundle-kubeflow/issues/570 was a challenge, partly because the charm has gone through recent rewrites that might have fixed the issue.  The specific cause of https://github.com/canonical/bundle-kubeflow/issues/570 could not be confirmed.  It may be fixed by this PR, but that is unclear.  More discussion on this is in [this thread](https://github.com/canonical/istio-operators/pull/277#discussion_r1214646654).

Closes https://github.com/canonical/bundle-kubeflow/issues/570

### Testing instructions

```bash
# pack the modified charm (from this PR)
cd charms/istio-pilot
charmcraft pack

# deploy istio, dex/oidc, and the dashboard to have something to browse to.  
# For the initial deployment, do this without certs/using http
juju deploy ./istio-pilot_ubuntu-20.04-amd64.charm --trust
juju deploy istio-gateway --channel=1.15/stable --trust --config kind=ingress istio-ingressgateway
juju relate istio-pilot istio-ingressgateway

juju deploy dex-auth --channel=2.31/stable --trust --config static-username=user --config static-password=user --config public-url=http://10.64.140.43.nip.io
juju deploy oidc-gatekeeper --channel ckf-1.7/stable --config public-url=http://10.64.140.43.nip.io
juju relate istio-pilot:ingress dex-auth:ingress
juju relate dex-auth:oidc-client oidc-gatekeeper:oidc-client
juju relate istio-pilot:ingress oidc-gatekeeper:ingress
juju relate istio-pilot:ingress-auth oidc-gatekeeper:ingress-auth

juju deploy kubeflow-profiles --channel=1.7/stable --trust
juju deploy kubeflow-dashboard --channel=1.7/stable --trust
juju relate kubeflow-profiles kubeflow-dashboard
juju relate kubeflow-dashboard:ingress istio-pilot:ingress

# Check whether everything works as expected
# try to connect to 
# * http://10.64.140.43.nip.io/: redirected to dex login 
# * http://10.64.140.43.nip.io/dex/.well-known/openid-configuration: works
# * https://10.64.140.43.nip.io/: cannot be reached
# * https://10.64.140.43.nip.io/dex/.well-known/openid-configuration: cannot be reached
# http all works, https all does not, as expected

# Set up SSL by creating a self-signed cert.  Note:
# * if you used a real cert, you wouldn't have to update the oidc-gatekeeper ca-bundle. 
# * you must have a common name and SAN in the self-signed cert

openssl req -nodes -new -x509 \
 -subj "/CN=10.64.140.43.nip.io" \
 -addext "subjectAltName = DNS:10.64.140.43.nip.io" \
 -keyout server-san.key -out server-san.cert 

juju config istio-pilot ssl-crt="$(cat server-san.cert | base64 -w0)"
juju config istio-pilot ssl-key="$(cat server-san.key | base64 -w0)" 

juju config dex-auth public-url=https://10.64.140.43.nip.io

# Because oidc for 1.7 does not restart its workload if you change the ca-bundle, we remove and redeploy it
juju remove-application oidc-gatekeeper
juju deploy oidc-gatekeeper --channel ckf-1.7/stable --config public-url=https://10.64.140.43.nip.io --config ca-bundle="$(cat server-san.cert)"

# Re-relate oidc
juju relate dex-auth:oidc-client oidc-gatekeeper:oidc-client
juju relate istio-pilot:ingress oidc-gatekeeper:ingress
juju relate istio-pilot:ingress-auth oidc-gatekeeper:ingress-auth

# wait for oidc/dex-auth to do their thing...

# Check whether everything works.  Now, we should only be able to reach http urls, not https
# * http://10.64.140.43.nip.io/: cannot be reached
# * http://10.64.140.43.nip.io/dex/.well-known/openid-configuration: cannot be reached
# * https://10.64.140.43.nip.io: warning about insecure cert, then redirected to dex login
# * https://10.64.140.43.nip.io/dex/.well-known/openid-configuration: warning about insecure cert, then it works
```
