### PR TITLE
fix: set field_manager to lightkube instead of istio-pilot

### DIFF
--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -90,7 +90,7 @@ class Operator(CharmBase):
         super().__init__(*args)
 
         self.log = logging.getLogger(__name__)
-        self._field_manager = self.app.name
+        self._field_manager = "lightkube"
 
         # Event handling for managing the Istio control plane
         self.framework.observe(self.on.install, self.install)
@@ -496,7 +496,7 @@ class Operator(CharmBase):
     @property
     def _lightkube_client(self):
         """Returns a lightkube client configured for this charm."""
-        return Client(namespace=self.model.name, field_manager=self.app.name)
+        return Client(namespace=self.model.name, field_manager=self._field_manager)
 
     def _send_gateway_info(self):
         """Sends gateway information to all related apps.


### PR DESCRIPTION
To keep some backwards compatibility with istio-pilot 1.16/stable rev413, we need to set back the `field_manager` vairable from `istio-pilot` (introduced by [df2e23b](https://github.com/canonical/istio-operators/blob/track/1.16/charms/istio-pilot/src/charm.py#L93)) to `lightkube`, as it was in the mentioned revision (see [state of charm](https://github.com/canonical/istio-operators/blame/fbacbd67d829df7113d90adc3a30559f7a7e0aa9/charms/istio-pilot/src/charm.py#L74) ~5 months ago); otherwise we'll get conflicts with certain patched/applied Kubernetes resources when refreshing from 1.16/stable rev413 to 1.16/edge rev 542 and higher.

[Error logs](https://pastebin.canonical.com/p/gqwgKkSBrZ/)