### PR TITLE
feat: get images for istio

### DIFF
--- a/tools/get-images-1.7-stable.sh
+++ b/tools/get-images-1.7-stable.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#
+# This script returns list of container images that are managed by this charm and/or its workload
+#
+# static list
+STATIC_IMAGE_LIST=(
+docker.io/istio/pilot:1.16.2
+)
+# dynamic list
+git checkout origin/track/1.16
+IMAGE_LIST=()
+IMAGE_LIST+=($(grep image charms/istio-gateway/src/manifest.yaml | awk '{print $2}' | sort --unique))
+
+
+printf "%s\n" "${STATIC_IMAGE_LIST[@]}"
+printf "%s\n" "${IMAGE_LIST[@]}"


### PR DESCRIPTION
Repository specific list of images.
Used by CVE scanning workflows and can be used to collect images URL for airgapped setup.

Summary of changes:
- Added script that retrieves image managed by charm(s).