### PR TITLE
Repository specific list of images.

### DIFF
--- a/tools/get-images.sh
+++ b/tools/get-images.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+#
+# This script returns list of container images that are managed by this charm and/or its workload
+#
+# static list
+STATIC_IMAGE_LIST=(
+docker.io/istio/pilot:1.16.2
+)
+# dynamic list
+IMAGE_LIST=()
+IMAGE_LIST+=($(grep image charms/istio-gateway/src/manifest.yaml | awk '{print $2}' | sort --unique))
+printf "%s\n" "${STATIC_IMAGE_LIST[@]}"
+printf "%s\n" "${IMAGE_LIST[@]}"


### PR DESCRIPTION
Used by CVE scanning workflows and can be used to collect images URL for airgapped setup. Script is specific for track/1.16 branch to capture all images for that branch. Branch is handled in kubeflow-ci and bundle automation using bundle file.

Summary of changes:
- Re-designed get images script to retrieve all images for current branch. Branch management is done outside of this script.