### PR TITLE
feat: bump istio-operators 1.16->1.17

### DIFF
--- a/charms/istio-gateway/src/manifest.yaml
+++ b/charms/istio-gateway/src/manifest.yaml
@@ -55,37 +55,8 @@ spec:
     spec:
       affinity:
         nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - preference:
-                matchExpressions:
-                  - key: kubernetes.io/arch
-                    operator: In
-                    values:
-                      - amd64
-              weight: 2
-            - preference:
-                matchExpressions:
-                  - key: kubernetes.io/arch
-                    operator: In
-                    values:
-                      - ppc64le
-              weight: 2
-            - preference:
-                matchExpressions:
-                  - key: kubernetes.io/arch
-                    operator: In
-                    values:
-                      - s390x
-              weight: 2
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: kubernetes.io/arch
-                    operator: In
-                    values:
-                      - amd64
-                      - ppc64le
-                      - s390x
+          preferredDuringSchedulingIgnoredDuringExecution: null
+          requiredDuringSchedulingIgnoredDuringExecution: null
       containers:
         - args:
             - proxy
@@ -145,9 +116,11 @@ spec:
               value: standard
             - name: ISTIO_META_CLUSTER_ID
               value: Kubernetes
-          image: docker.io/istio/proxyv2:1.16.2
+          image: docker.io/istio/proxyv2:1.17.3
           name: istio-proxy
           ports:
+            - containerPort: 15021
+              protocol: TCP
             - containerPort: 8080
               protocol: TCP
             - containerPort: 8443
@@ -180,12 +153,12 @@ spec:
             privileged: false
             readOnlyRootFilesystem: true
           volumeMounts:
-            - name: workload-socket
-              mountPath: /var/run/secrets/workload-spiffe-uds
-            - name: credential-socket
-              mountPath: /var/run/secrets/credential-uds
-            - name: workload-certs
-              mountPath: /var/run/secrets/workload-spiffe-credentials
+            - mountPath: /var/run/secrets/workload-spiffe-uds
+              name: workload-socket
+            - mountPath: /var/run/secrets/credential-uds
+              name: credential-socket
+            - mountPath: /var/run/secrets/workload-spiffe-credentials
+              name: workload-certs
             - mountPath: /etc/istio/proxy
               name: istio-envoy
             - mountPath: /etc/istio/config
@@ -254,6 +227,10 @@ spec:
             optional: true
             secretName: istio-{{ kind }}gateway-workload-ca-certs
 ---
+# Remove the PodDisruptionBudget as a workaround for https://github.com/istio/istio/issues/12602
+# and https://github.com/istio/istio/issues/24000
+# According to kubeflow/manifests istio installation instruction as well
+$patch: delete
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/charms/istio-gateway/tests/unit/data/egress-example.yaml
+++ b/charms/istio-gateway/tests/unit/data/egress-example.yaml
@@ -54,44 +54,14 @@ spec:
     spec:
       affinity:
         nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - preference:
-                matchExpressions:
-                  - key: kubernetes.io/arch
-                    operator: In
-                    values:
-                      - amd64
-              weight: 2
-            - preference:
-                matchExpressions:
-                  - key: kubernetes.io/arch
-                    operator: In
-                    values:
-                      - ppc64le
-              weight: 2
-            - preference:
-                matchExpressions:
-                  - key: kubernetes.io/arch
-                    operator: In
-                    values:
-                      - s390x
-              weight: 2
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: kubernetes.io/arch
-                    operator: In
-                    values:
-                      - amd64
-                      - ppc64le
-                      - s390x
+          preferredDuringSchedulingIgnoredDuringExecution: null
+          requiredDuringSchedulingIgnoredDuringExecution: null
       containers:
         - args:
             - proxy
             - router
             - --domain
             - None.svc.cluster.local
-            # - $(POD_NAMESPACE).svc.cluster.local
             - --proxyLogLevel=warning
             - --proxyComponentLogLevel=misc:error
             - --log_output_level=default:info
@@ -100,7 +70,6 @@ spec:
               value: third-party-jwt
             - name: PILOT_CERT_PROVIDER
               value: service-name
-              # value: istiod
             - name: CA_ADDR
               value: service-name:6666
             - name: NODE_NAME
@@ -146,9 +115,11 @@ spec:
               value: standard
             - name: ISTIO_META_CLUSTER_ID
               value: Kubernetes
-          image: docker.io/istio/proxyv2:1.16.2
+          image: docker.io/istio/proxyv2:1.17.3
           name: istio-proxy
           ports:
+            - containerPort: 15021
+              protocol: TCP
             - containerPort: 8080
               protocol: TCP
             - containerPort: 8443
@@ -181,12 +152,12 @@ spec:
             privileged: false
             readOnlyRootFilesystem: true
           volumeMounts:
-            - name: workload-socket
-              mountPath: /var/run/secrets/workload-spiffe-uds
-            - name: credential-socket
-              mountPath: /var/run/secrets/credential-uds
-            - name: workload-certs
-              mountPath: /var/run/secrets/workload-spiffe-credentials
+            - mountPath: /var/run/secrets/workload-spiffe-uds
+              name: workload-socket
+            - mountPath: /var/run/secrets/credential-uds
+              name: credential-socket
+            - mountPath: /var/run/secrets/workload-spiffe-credentials
+              name: workload-certs
             - mountPath: /etc/istio/proxy
               name: istio-envoy
             - mountPath: /etc/istio/config

--- a/charms/istio-gateway/tests/unit/data/ingress-example.yaml
+++ b/charms/istio-gateway/tests/unit/data/ingress-example.yaml
@@ -226,10 +226,6 @@ spec:
             optional: true
             secretName: istio-ingressgateway-workload-ca-certs
 ---
-# Remove the PodDisruptionBudget as a workaround for https://github.com/istio/istio/issues/12602
-# and https://github.com/istio/istio/issues/24000
-# According to kubeflow/manifests istio installation instruction as well
-$patch: delete
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/charms/istio-gateway/tests/unit/data/ingress-example.yaml
+++ b/charms/istio-gateway/tests/unit/data/ingress-example.yaml
@@ -54,44 +54,14 @@ spec:
     spec:
       affinity:
         nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - preference:
-                matchExpressions:
-                  - key: kubernetes.io/arch
-                    operator: In
-                    values:
-                      - amd64
-              weight: 2
-            - preference:
-                matchExpressions:
-                  - key: kubernetes.io/arch
-                    operator: In
-                    values:
-                      - ppc64le
-              weight: 2
-            - preference:
-                matchExpressions:
-                  - key: kubernetes.io/arch
-                    operator: In
-                    values:
-                      - s390x
-              weight: 2
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: kubernetes.io/arch
-                    operator: In
-                    values:
-                      - amd64
-                      - ppc64le
-                      - s390x
+          preferredDuringSchedulingIgnoredDuringExecution: null
+          requiredDuringSchedulingIgnoredDuringExecution: null
       containers:
         - args:
             - proxy
             - router
             - --domain
             - None.svc.cluster.local
-            # - $(POD_NAMESPACE).svc.cluster.local
             - --proxyLogLevel=warning
             - --proxyComponentLogLevel=misc:error
             - --log_output_level=default:info
@@ -100,7 +70,6 @@ spec:
               value: third-party-jwt
             - name: PILOT_CERT_PROVIDER
               value: service-name
-              # value: istiod
             - name: CA_ADDR
               value: service-name:6666
             - name: NODE_NAME
@@ -146,9 +115,11 @@ spec:
               value: standard
             - name: ISTIO_META_CLUSTER_ID
               value: Kubernetes
-          image: docker.io/istio/proxyv2:1.16.2
+          image: docker.io/istio/proxyv2:1.17.3
           name: istio-proxy
           ports:
+            - containerPort: 15021
+              protocol: TCP
             - containerPort: 8080
               protocol: TCP
             - containerPort: 8443
@@ -181,12 +152,12 @@ spec:
             privileged: false
             readOnlyRootFilesystem: true
           volumeMounts:
-            - name: workload-socket
-              mountPath: /var/run/secrets/workload-spiffe-uds
-            - name: credential-socket
-              mountPath: /var/run/secrets/credential-uds
-            - name: workload-certs
-              mountPath: /var/run/secrets/workload-spiffe-credentials
+            - mountPath: /var/run/secrets/workload-spiffe-uds
+              name: workload-socket
+            - mountPath: /var/run/secrets/credential-uds
+              name: credential-socket
+            - mountPath: /var/run/secrets/workload-spiffe-credentials
+              name: workload-certs
             - mountPath: /etc/istio/proxy
               name: istio-envoy
             - mountPath: /etc/istio/config
@@ -255,6 +226,10 @@ spec:
             optional: true
             secretName: istio-ingressgateway-workload-ca-certs
 ---
+# Remove the PodDisruptionBudget as a workaround for https://github.com/istio/istio/issues/12602
+# and https://github.com/istio/istio/issues/24000
+# According to kubeflow/manifests istio installation instruction as well
+$patch: delete
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/charms/istio-pilot/charmcraft.yaml
+++ b/charms/istio-pilot/charmcraft.yaml
@@ -13,5 +13,5 @@ parts:
     build-packages: [git]
   istioctl:
     plugin: dump
-    source: https://github.com/istio/istio/releases/download/1.16.2/istioctl-1.16.2-linux-amd64.tar.gz
+    source: https://github.com/istio/istio/releases/download/1.17.3/istioctl-1.17.3-linux-amd64.tar.gz
     source-type: tar

--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -39,7 +39,7 @@ ENVOYFILTER_LIGHTKUBE_RESOURCE = create_namespaced_resource(
     group="networking.istio.io", version="v1alpha3", kind="EnvoyFilter", plural="envoyfilters"
 )
 GATEWAY_LIGHTKUBE_RESOURCE = create_namespaced_resource(
-    group="networking.istio.io", version="v1beta1", kind="Gateway", plural="gateways"
+    group="networking.istio.io", version="v1alpha3", kind="Gateway", plural="gateways"
 )
 VIRTUAL_SERVICE_LIGHTKUBE_RESOURCE = create_namespaced_resource(
     group="networking.istio.io",

--- a/charms/istio-pilot/src/manifests/gateway.yaml.j2
+++ b/charms/istio-pilot/src/manifests/gateway.yaml.j2
@@ -1,5 +1,5 @@
 ---
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
   name: {{ gateway_name }}

--- a/charms/istio-pilot/tests/unit/test_charm.py
+++ b/charms/istio-pilot/tests/unit/test_charm.py
@@ -41,7 +41,7 @@ from charm import (
 from istioctl import IstioctlError
 
 GATEWAY_LIGHTKUBE_RESOURCE = create_namespaced_resource(
-    group="networking.istio.io", version="v1beta1", kind="Gateway", plural="gateways"
+    group="networking.istio.io", version="v1alpha3", kind="Gateway", plural="gateways"
 )
 
 VIRTUAL_SERVICE_LIGHTKUBE_RESOURCE = create_namespaced_resource(


### PR DESCRIPTION
This PR introduces the following changes:

* Bump the istioctl binary 1.16 -> 1.17
* Bump the API version of Gateway `v1beta1` -> `v1alpha3`
* Bump the docker.io/istio/proxyv2 image tag from 1.16 -> 1.17.3
* Delete the `PodDisruptionBudget` from the cluster due to https://github.com/istio/istio/issues/12602 and https://github.com/istio/istio/issues/24000
* Set the following to
```
preferredDuringSchedulingIgnoredDuringExecution: null
requiredDuringSchedulingIgnoredDuringExecution: null
```
in the `Gateway` deployment according to https://github.com/kubeflow/manifests/pull/2426


All these updates were made using https://github.com/kubeflow/manifests/pull/2483 as reference.

> NOTE: The changes in this PR may require microk8s > 1.24/stable, the CI may need #310 to be merged before it goes green.