### PR TITLE
chore: remove patches for istio < 1.16

### DIFF
--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -172,13 +172,6 @@ class Operator(CharmBase):
             ]
         )
 
-        # Patch any known issues with the install
-        # Istioctl v1.12-1.14 have a bug where the validating webhook is not deployed to the
-        # correct namespace (see https://github.com/canonical/istio-operators/issues/204)
-        # This has no effect if the webhook does not exist or is already correct
-        self._log_and_set_status(MaintenanceStatus("Patching webhooks"))
-        self._patch_istio_validating_webhook()
-
         self.unit.status = ActiveStatus()
 
     def reconcile(self, event):
@@ -350,14 +343,6 @@ class Operator(CharmBase):
             MaintenanceStatus("Waiting for Istio upgrade to roll out in cluster")
         )
         _wait_for_update_rollout(istioctl, RETRY_FOR_15_MINUTES, self.log)
-
-        # Patch any known issues with the upgrade
-        client_version = Version(versions["client"])
-        if Version("1.12.0") <= client_version < Version("1.15.0"):
-            self._log_and_set_status(
-                MaintenanceStatus(f"Fixing webhooks from upgrade to {str(client_version)}")
-            )
-            self._patch_istio_validating_webhook()
 
         self.log.info("Upgrade complete.")
         self.unit.status = ActiveStatus()
@@ -739,43 +724,6 @@ class Operator(CharmBase):
         }
 
         log_destination_map[type(status)](status.message)
-
-    def _patch_istio_validating_webhook(self):
-        """Patch ValidatingWebhookConfiguration from istioctl v1.12-v1.14 to use correct namespace.
-
-        istioctl v1.12, v1.13, and v1.14 have a bug where the ValidatingWebhookConfiguration
-        istiod-default-validator looks for istiod in the `istio-system` namespace rather than the
-        namespace actually used for istio.  This function patches this webhook configuration to
-        use the correct namespace.
-
-        If the webhook configuration does not exist or is already correct, this has no effect.
-        """
-        self.log.info(
-            "Attempting to patch istiod-default-validator webhook to ensure it points to"
-            " correct namespace."
-        )
-        lightkube_client = self._lightkube_client
-        try:
-            vwc = lightkube_client.get(
-                ValidatingWebhookConfiguration, name="istiod-default-validator"
-            )
-        except ApiError as e:
-            # If the webhook doesn't exist, we don't need to patch it
-            self.log.info("No istiod-default-validator webhook found - skipping patch operation.")
-            if e.status.code == 404:
-                return
-            raise e
-
-        vwc.metadata.managedFields = None
-        vwc.webhooks[0].clientConfig.service.namespace = self.model.name
-        lightkube_client.patch(
-            ValidatingWebhookConfiguration,
-            "istiod-default-validator",
-            vwc,
-            field_manager=self.app.name,
-            force=True,
-        )
-        self.log.info("istiod-default-validator webhook successfully patched")
 
     def _use_https(self):
         if _xor(self.model.config["ssl-crt"], self.model.config["ssl-key"]):

--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -20,7 +20,6 @@ from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
 from lightkube import Client
 from lightkube.core.exceptions import ApiError
 from lightkube.generic_resource import create_namespaced_resource
-from lightkube.resources.admissionregistration_v1 import ValidatingWebhookConfiguration
 from lightkube.resources.core_v1 import Secret, Service
 from ops.charm import CharmBase, RelationBrokenEvent
 from ops.main import main

--- a/charms/istio-pilot/tests/unit/test_charm.py
+++ b/charms/istio-pilot/tests/unit/test_charm.py
@@ -12,12 +12,6 @@ from charmed_kubeflow_chisme.lightkube.mocking import FakeApiError
 from lightkube import codecs
 from lightkube.core.exceptions import ApiError
 from lightkube.generic_resource import create_namespaced_resource
-from lightkube.models.admissionregistration_v1 import (
-    ServiceReference,
-    ValidatingWebhook,
-    ValidatingWebhookConfiguration,
-    WebhookClientConfig,
-)
 from lightkube.models.meta_v1 import ObjectMeta
 from lightkube.resources.core_v1 import Secret
 from ops.charm import (
@@ -1124,7 +1118,6 @@ class TestCharmUpgrade:
     def test_validate_upgrade_version(self, versions, context_raised):
         with context_raised:
             _validate_upgrade_version(versions)
-
 
     @patch("charm.Istioctl", return_value=MagicMock())
     def test_wait_for_update_rollout(self, mocked_istioctl_class):

--- a/charms/istio-pilot/tests/unit/test_charm.py
+++ b/charms/istio-pilot/tests/unit/test_charm.py
@@ -1034,7 +1034,6 @@ class TestCharmHelpers:
 class TestCharmUpgrade:
     """Tests for charm upgrade handling."""
 
-    @patch("charm.Operator._patch_istio_validating_webhook")  # Do not patch istio installs
     @patch("charm._wait_for_update_rollout")  # Do not wait for upgrade to finish
     @patch("charm._validate_upgrade_version")  # Do not validate versions
     @patch("charm.Istioctl", return_value=MagicMock())
@@ -1043,7 +1042,6 @@ class TestCharmUpgrade:
         mocked_istioctl_class,
         _mocked_validate_upgrade_version,
         mocked_wait_for_update_rollout,
-        _mocked_patch_istio_validating_webhook,
         harness,
     ):
         """Tests that charm.upgrade_charm works successfully when expected."""
@@ -1053,7 +1051,7 @@ class TestCharmUpgrade:
         mocked_istioctl = mocked_istioctl_class.return_value
 
         # Return valid version data from istioctl.versions
-        mocked_istioctl.version.return_value = {"client": "1.12.5", "control_plane": "1.12.5"}
+        mocked_istioctl.version.return_value = {"client": "1.15.7", "control_plane": "1.15.7"}
 
         # Simulate the upgrade
         harness.begin()
@@ -1127,54 +1125,6 @@ class TestCharmUpgrade:
         with context_raised:
             _validate_upgrade_version(versions)
 
-    def test_patch_istio_validating_webhook(self, harness, mocked_lightkube_client):
-        """Tests that _patch_istio_validating_webhook works as expected."""
-        model_name = "test-model"
-        harness.set_model_name(model_name)
-        harness.begin()
-
-        mock_vwc = ValidatingWebhookConfiguration(
-            metadata=ObjectMeta(name="istiod-default-validator"),
-            webhooks=[
-                ValidatingWebhook(
-                    admissionReviewVersions=[""],
-                    name="",
-                    sideEffects=None,
-                    clientConfig=WebhookClientConfig(
-                        service=ServiceReference(
-                            name="istiod",
-                            namespace="istio-system",
-                        )
-                    ),
-                )
-            ],
-        )
-
-        mocked_lightkube_client.get.return_value = mock_vwc
-
-        harness.charm._patch_istio_validating_webhook()
-
-        # Confirm we've tried to apply a patched version of the webhook
-        patch_call = mocked_lightkube_client.patch.call_args_list[0]
-        # Assert the expected webhook is being patched
-        assert patch_call[0][1] == "istiod-default-validator"
-        # Assert that we've patched to the expected model name
-        vwc = patch_call[0][2]
-        assert vwc.webhooks[0].clientConfig.service.namespace == model_name
-
-    def test_patch_istio_validating_webhook_for_webhook_does_not_exist(
-        self, harness, mocked_lightkube_client
-    ):
-        """Tests that charm._patch_istio_validating_webhook does not fail if webhook missing."""
-        harness.begin()
-
-        mocked_lightkube_client = MagicMock()
-        mocked_lightkube_client.get.side_effect = FakeApiError(404)
-
-        harness.charm._patch_istio_validating_webhook()
-
-        # Confirm we've not tried to apply anything
-        assert mocked_lightkube_client.patch.call_count == 0
 
     @patch("charm.Istioctl", return_value=MagicMock())
     def test_wait_for_update_rollout(self, mocked_istioctl_class):

--- a/charms/istio-pilot/tests/unit/test_charm.py
+++ b/charms/istio-pilot/tests/unit/test_charm.py
@@ -1054,7 +1054,6 @@ class TestCharmUpgrade:
         # Assert that the upgrade was successful
         mocked_istioctl_class.assert_called_with("./istioctl", model_name, "minimal")
         mocked_istioctl.upgrade.assert_called_with()
-        harness.charm._patch_istio_validating_webhook.assert_called_with()
 
         mocked_wait_for_update_rollout.assert_called_once()
 


### PR DESCRIPTION
Istio 1.12-1.14 had an issue with the ValidatingWebhookConfiguration and the namespace, which we patched in the charm code to prevent errros. Since this issue is not present in recent versions of the charm, we do not need the workaround anymore. This code is still valid in previous versions and can be left in those branches.