### PR TITLE
build: unpin setuptools and pip in charmcraft.yaml as pypa/setuptools_scm#713 is fixed

### DIFF
--- a/charms/istio-gateway/charmcraft.yaml
+++ b/charms/istio-gateway/charmcraft.yaml
@@ -8,5 +8,4 @@ bases:
         channel: '20.04'
 parts:
   charm:
-    # Remove when pypa/setuptools_scm#713 gets fixed
-    charm-python-packages: [setuptools==62.1.0, pip==22.0.4]
+    charm-python-packages: [setuptools, pip]

--- a/charms/istio-pilot/charmcraft.yaml
+++ b/charms/istio-pilot/charmcraft.yaml
@@ -8,8 +8,7 @@ bases:
       channel: "20.04"
 parts:
   charm:
-    # Remove when pypa/setuptools_scm#713 gets fixed
-    charm-python-packages: [setuptools==62.1.0, pip==22.0.4]
+    charm-python-packages: [setuptools, pip]
     build-packages: [git]
   istioctl:
     plugin: dump


### PR DESCRIPTION
This pin is not needed anymore, and in fact we want the latest versions of setuptools and pip.