### PR TITLE
feat: get images on main

### DIFF
--- a/tools/get-images.sh
+++ b/tools/get-images.sh
@@ -4,13 +4,10 @@
 #
 # static list
 STATIC_IMAGE_LIST=(
-docker.io/istio/pilot:1.16.2
+docker.io/istio/pilot:1.17.3
 )
 # dynamic list
-git checkout origin/track/1.16
 IMAGE_LIST=()
 IMAGE_LIST+=($(grep image charms/istio-gateway/src/manifest.yaml | awk '{print $2}' | sort --unique))
-
-
 printf "%s\n" "${STATIC_IMAGE_LIST[@]}"
 printf "%s\n" "${IMAGE_LIST[@]}"


### PR DESCRIPTION
Refer to this issue for more details: https://github.com/canonical/bundle-kubeflow/issues/679

Summary of changes:
- Added script that produces list of container images managed by charms in this repository and/or by corresponding workloads. Image list is a combination of static and dynamic lists.

NOTE: Static list in this script assumes pilot version 1.17.3 which is part of Charmed Kubeflow 1.8 release.
NOTE: Script replaced outdated get-images-1.7-stable.sh script.