### PR TITLE
fix: pin prometheus to specific revision

### DIFF
--- a/tests/test_cos_integration.py
+++ b/tests/test_cos_integration.py
@@ -53,7 +53,17 @@ async def test_prometheus_grafana_integration_istio_pilot(ops_test: OpsTest):
     scrape_config = {"scrape_interval": "30s"}
 
     # Deploy and relate prometheus
-    await ops_test.model.deploy(prometheus, channel="latest/stable", trust=True)
+    # FIXME: Unpin revision once https://github.com/canonical/bundle-kubeflow/issues/688 is closed
+    await ops_test.juju(
+        "deploy",
+        prometheus,
+        "--channel",
+        "latest/edge",
+        "--revision",
+        "137",
+        "--trust",
+        check=True,
+    )
     await ops_test.model.deploy(prometheus_scrape, channel="latest/stable", config=scrape_config)
 
     await ops_test.model.add_relation(ISTIO_PILOT, prometheus_scrape)


### PR DESCRIPTION
# Description
Prometheus updates on `latest/edge` require Juju > 3.0.3. Temporary pin to the revisions that will allow integration tests to deploy those charms.

More details are in:
- https://github.com/canonical/bundle-kubeflow/issues/688

# Summary of changes
- Pinned revisions of prometheus to avoid failure of integration tests. Refer to above issue for more details.