### PR TITLE
fix: set charm to waitingStatus if missing ingress auth data

### DIFF
--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -440,6 +440,10 @@ class Operator(CharmBase):
                 if app != self.app
             }
 
+            # Go into waiting status if there is no ingress-auth data
+            if not ingress_auth_data:
+                raise ErrorWithStatus("Waiting for the auth provider data.", WaitingStatus)
+
             # We only support a single ingress-auth relation, so we can unpack and return just the
             # contents
             if len(ingress_auth_data) > 1:

--- a/charms/istio-pilot/tests/unit/test_charm.py
+++ b/charms/istio-pilot/tests/unit/test_charm.py
@@ -222,6 +222,8 @@ class TestCharmEvents:
 
         harness.begin()
 
+        harness.charm.log = MagicMock()
+
         # Do a reconcile
         harness.charm.on.config_changed.emit()
 
@@ -234,8 +236,12 @@ class TestCharmEvents:
 
         # Add "broken" ingress_auth (empty data) and check that we remove the gateway
         rel_id = harness.add_relation("ingress-auth", "other")
+        add_data_to_sdi_relation(harness, rel_id, "other", {})
         mocked_remove_gateway.assert_called_once
         mocked_remove_gateway.reset_mock()
+
+        assert harness.charm.model.unit.status == WaitingStatus("Execution handled 1 errors.  See logs for details.")
+        assert "Handled error 0/1: WaitingStatus('Waiting for the auth provider data.')" in harness.charm.log.info.call_args.args
 
         # Remove ingress_auth relation and check that we re-add the gateway
         harness.remove_relation(rel_id)
@@ -538,6 +544,17 @@ class TestCharmHelpers:
         ingress_auth_data = harness.charm._get_ingress_auth_data("not-relation-broken-event")
 
         assert len(ingress_auth_data) == 0
+
+    def test_get_ingress_auth_data_empty_error(self, harness):
+        """Tests that the _get_ingress_auth_data helper returns the correct relation data."""
+        harness.begin()
+        rel_id = harness.add_relation("ingress-auth", "other")
+        add_data_to_sdi_relation(harness, rel_id, "other", {})
+        with pytest.raises(ErrorWithStatus) as err:
+            ingress_auth_data = harness.charm._get_ingress_auth_data("not-relation-broken-event")
+
+        assert err.value.status_type.name == "waiting"
+        assert "Waiting for the auth provider data." == err.value.msg
 
     def test_get_ingress_auth_data_too_many_relations(self, harness):
         """Tests that the _get_ingress_auth_data helper raises on too many relations data."""

--- a/charms/istio-pilot/tests/unit/test_charm.py
+++ b/charms/istio-pilot/tests/unit/test_charm.py
@@ -240,8 +240,13 @@ class TestCharmEvents:
         mocked_remove_gateway.assert_called_once
         mocked_remove_gateway.reset_mock()
 
-        assert harness.charm.model.unit.status == WaitingStatus("Execution handled 1 errors.  See logs for details.")
-        assert "Handled error 0/1: WaitingStatus('Waiting for the auth provider data.')" in harness.charm.log.info.call_args.args
+        assert harness.charm.model.unit.status == WaitingStatus(
+            "Execution handled 1 errors.  See logs for details."
+        )
+        assert (
+            "Handled error 0/1: WaitingStatus('Waiting for the auth provider data.')"
+            in harness.charm.log.info.call_args.args
+        )
 
         # Remove ingress_auth relation and check that we re-add the gateway
         harness.remove_relation(rel_id)
@@ -551,7 +556,7 @@ class TestCharmHelpers:
         rel_id = harness.add_relation("ingress-auth", "other")
         add_data_to_sdi_relation(harness, rel_id, "other", {})
         with pytest.raises(ErrorWithStatus) as err:
-            ingress_auth_data = harness.charm._get_ingress_auth_data("not-relation-broken-event")
+            harness.charm._get_ingress_auth_data("not-relation-broken-event")
 
         assert err.value.status_type.name == "waiting"
         assert "Waiting for the auth provider data." == err.value.msg


### PR DESCRIPTION
Put istio-pilot into waitingStatus until the ingress-auth data provider changes the data in the relation data bag.

Fixes #336 
Fixes #346