### PR TITLE
Handle None being returned for ingresses

### DIFF
--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -827,11 +827,10 @@ def _get_address_from_loadbalancer(svc):
           (str): The hostname or IP address of the LoadBalancer service
     """
     ingresses = svc.status.loadBalancer.ingress
-    if len(ingresses) != 1:
-        if len(ingresses) == 0:
-            return None
-        else:
-            raise ValueError("Unknown situation - LoadBalancer service has more than one ingress")
+    if ingresses is None or len(ingresses) == 0:
+        return None
+    elif len(ingresses) != 1:
+        raise ValueError("Unknown situation - LoadBalancer service has more than one ingress")
 
     ingress = svc.status.loadBalancer.ingress[0]
     if getattr(ingress, "hostname", None) is not None:

--- a/charms/istio-pilot/tests/unit/test_charm.py
+++ b/charms/istio-pilot/tests/unit/test_charm.py
@@ -513,6 +513,7 @@ class TestCharmHelpers:
             ("mock_loadbalancer_ip_service", True),
             ("mock_loadbalancer_hostname_service_not_ready", False),
             ("mock_loadbalancer_ip_service_not_ready", False),
+            ("mock_loadbalancer_service_not_ready_returning_none_for_ingresses", False),
         ],
     )
     def test_is_gateway_service_up(
@@ -542,6 +543,7 @@ class TestCharmHelpers:
             ("mock_loadbalancer_ip_service", "127.0.0.1"),
             ("mock_loadbalancer_hostname_service_not_ready", None),
             ("mock_loadbalancer_ip_service_not_ready", None),
+            ("mock_loadbalancer_service_not_ready_returning_none_for_ingresses", None),
         ],
     )
     def test_get_gateway_address_from_svc(
@@ -1430,6 +1432,18 @@ def mock_loadbalancer_hostname_service_not_ready():
             "apiVersion": "v1",
             "kind": "Service",
             "status": {"loadBalancer": {"ingress": []}},
+            "spec": {"type": "LoadBalancer", "clusterIP": "10.10.10.10"},
+        }
+    )
+    return mock_nodeport_service
+
+@pytest.fixture()
+def mock_loadbalancer_service_not_ready_returning_none_for_ingresses():
+    mock_nodeport_service = codecs.from_dict(
+        {
+            "apiVersion": "v1",
+            "kind": "Service",
+            "status": {"loadBalancer": {"ingress": None}},
             "spec": {"type": "LoadBalancer", "clusterIP": "10.10.10.10"},
         }
     )


### PR DESCRIPTION
`svc.status.loadBalancer.ingress` has been observed to return `None` in certain situations and leads to failure of the `ingress-relation-created` hook.  This change handles the `None` and treats the situation as if no ingresses are present.