### PR TITLE
ci: use charmcraft latest/candidate instead of latest/edge

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -63,7 +63,7 @@ jobs:
           channel: ${{ matrix.microk8s-versions }}
           microk8s-addons: "dns hostpath-storage rbac metallb:10.64.140.43-10.64.140.49"
           juju-channel: 3.1/stable
-          charmcraft-channel: latest/edge
+          charmcraft-channel: latest/candidate
   
       - name: Run integration tests
         run: |
@@ -130,7 +130,7 @@ jobs:
           channel: ${{ matrix.microk8s-versions }}
           microk8s-addons: "dns hostpath-storage rbac metallb:10.64.140.43-10.64.140.49"
           juju-channel: 3.1/stable
-          charmcraft-channel: latest/edge
+          charmcraft-channel: latest/candidate
  
       - name: Run observability integration tests
         run: |

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -63,7 +63,7 @@ jobs:
           channel: ${{ matrix.microk8s-versions }}
           microk8s-addons: "dns hostpath-storage rbac metallb:10.64.140.43-10.64.140.49"
           juju-channel: 3.1/stable
-          charmcraft-channel: latest/candidate
+          charmcraft-channel: latest/edge
   
       - name: Run integration tests
         run: |
@@ -130,7 +130,7 @@ jobs:
           channel: ${{ matrix.microk8s-versions }}
           microk8s-addons: "dns hostpath-storage rbac metallb:10.64.140.43-10.64.140.49"
           juju-channel: 3.1/stable
-          charmcraft-channel: latest/candidate
+          charmcraft-channel: latest/edge
  
       - name: Run observability integration tests
         run: |


### PR DESCRIPTION
Use the latest candidate version of charmcraft to avoid potential issues with the edge version of charmcraft.
This commit is specifically reacting to canonical/craft-application#167

> NOTE: this change makes sure that the repository is aligned with our other repositories, most of them (with very few exceptions) point to latest/candidate.