### PR TITLE
feat: enable Istio CNI plugin by default

### DIFF
--- a/charms/istio-pilot/config.yaml
+++ b/charms/istio-pilot/config.yaml
@@ -1,4 +1,12 @@
 options:
+  cni-bin-dir:
+    type: string
+    default: ''
+    description: Path to CNI binaries, e.g. /opt/cni/bin. This configuration option will only work when first deploying istio.
+  cni-conf-dir:
+    type: string
+    default: ''
+    description: Path to conflist files describing the CNI configuration, e.g. /etc/cni/net.d. This configuration option will only work when first deploying istio.
   default-gateway:
     type: string
     default: istio-gateway

--- a/charms/istio-pilot/config.yaml
+++ b/charms/istio-pilot/config.yaml
@@ -2,11 +2,17 @@ options:
   cni-bin-dir:
     type: string
     default: ''
-    description: Path to CNI binaries, e.g. /opt/cni/bin. This configuration option will only work when first deploying istio.
+    description: >
+      Path to CNI binaries, e.g. /opt/cni/bin. If not provided, the Istio control plane will be installed/upgraded with the Istio CNI plugin disabled.
+      This path depends on the Kubernetes installation, please refer to https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/
+      for information to find out the correct path.
   cni-conf-dir:
     type: string
     default: ''
-    description: Path to conflist files describing the CNI configuration, e.g. /etc/cni/net.d. This configuration option will only work when first deploying istio.
+    description: Path to conflist files describing the CNI configuration, e.g. /etc/cni/net.d. If not provided, the Istio control plane will be installed/upgraded
+      with the Istio CNI plugin disabled.
+      This path depends on the Kubernetes installation, please refer to https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/
+      for information to find out the correct path.
   default-gateway:
     type: string
     default: istio-gateway


### PR DESCRIPTION
feat: enable Istio CNI plugin by default
    
This commit enables the Istio CNI plugin by default in all new
deployments of istio-pilot provided the required charm configuration is
present; otherwise the control plane remains intact.
It is also ensured that the required configurations are present when
upgrading to future versions so the plugin is correctly installed on
existing control planes (versions <1.17).
    
Fixes #356
Part of #351

#### Testing instructions

Env:
* microk8s 1.25-strict/stable
* microk8s enable dns hostpath-storage rbac metallb:10.64.140.43-10.64.140.49
* juju 3.1
* juju controller same version ^

<details>
<summary> Test charm installation </summary>

1. Set env variables
```
DEFAULT_GATEWAY="test-gateway"
KNATIVE_CHANNEL="latest/edge"
```
2. Build and deploy `istio-pilot` from this branch ` juju deploy ./istio-pilot_ubuntu-20.04-amd64.charm --config default-gateway=${DEFAULT_GATEWAY} --trust --config cni-bin-dir=<path to cni bin dir> --config cni-conf-dir=<path to cni bin dir>`

For microk8s these values are:
* /var/snap/microk8s/current/opt/cni/bin
* /var/snap/microk8s/current/args/cni-network

3. Deploy `istio-gateway` from Charmhub `juju deploy istio-gateway istio-ingressgateway --config kind="ingress" --channel latest/edge --trust`
4. Relate istio apps ` juju relate istio-pilot istio-ingressgateway`
5. Wait for them to be active and idle
6. Check that a new Pod (istio-cni-xxxx) in the model namespace is created.

##### Test integration with other charms and fix for #356 
1. Deploy kserve, knative and profile operators
```
juju deploy knative-operator --channel ${KNATIVE_CHANNEL} --trust
juju deploy knative-serving --config namespace="knative-serving" --config istio.gateway.namespace=${MODEL_NAME} --config istio.gateway.name=${DEFAULT_GATEWAY} --channel ${KNATIVE_CHANNEL} --trust
juju deploy kubeflow-profiles --channel latest/edge --trust
juju deploy kserve-controller --channel latest/edge --config deployment-mode="serverless" --trust
```
2. Add required relations
```
juju relate istio-pilot:gateway-info kserve-controller:ingress-gateway
juju relate kserve-controller:local-gateway knative-serving:local-gateway
```
3. Create a profile `kubectl apply -f https://raw.githubusercontent.com/canonical/kubeflow-profiles-operator/main/tests/integration/profile.yaml`
4. Create a `ISVC` in the recently created profile namespace `kubectl -f https://raw.githubusercontent.com/canonical/kserve-operators/main/charms/kserve-controller/tests/integration/sklearn-iris.yaml -nprofilename`
5. Check the pod for the `isvc` goes to a `Running` state and the `isvc` readiness is True. You could also perform inference following [this](https://raw.githubusercontent.com/canonical/kserve-operators/main/charms/kserve-controller/tests/integration/sklearn-iris.yaml) guide.
</details>

<details>
<summary> Test charm upgrade </summary>

1. Set env variables
```
DEFAULT_GATEWAY="test-gateway"
```

2. Deploy `istio-pilot` from Charmhub `juju deploy istio-pilot --channel latest/edge --trust`

3. Deploy `istio-gateway` from Charmhub `juju deploy istio-gateway istio-ingressgateway --config kind="ingress" --channel latest/edge --trust`

4. Relate istio apps ` juju relate istio-pilot istio-ingressgateway`

5. Wait for them to be active and idle

7. Build and refresh `istio-pilot` from this branch ` juju refresh istio-pilot  --path=./istio-pilot_ubuntu-20.04-amd64.charm`

8. The upgrade by itself won't install the cni-plugin, we must provide the cni configurations for the plugin to be enabled:

```
juju config istio-pilot cni-bin-dir=<path to cni bin dir> 
juju config istio-pilot cni-conf-dir=<path to cni bin dir>`
```

For microk8s these values are:
* /var/snap/microk8s/current/opt/cni/bin
* /var/snap/microk8s/current/args/cni-network

9. To verify the plugin was installed, we can check the pods in the model namespace, there should be an `istio-cni-xxxx` Pod present. This is not the case when the plugin is disabled. To do a more extensive test, you can follow the steps in "Test integration with other charms and fix for #356" from a previos section.

</details>
TODO:

- [x] Fix unit tests and add test cases where needed
- [x] Add manual testing instructions