### PR TITLE
feat: set meshConfig.accessLogFile configuration for exposing logs

### DIFF
--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -193,6 +193,7 @@ class Operator(CharmBase):
 
         # Extra flags to pass to the istioctl install command
         # These flags will configure the container images used by the control plane
+        # As well as set the access log files for help during debugging
         extra_flags = [
             "--set",
             f"values.pilot.image={pilot_image}",
@@ -204,6 +205,8 @@ class Operator(CharmBase):
             f"values.global.proxy.image={global_proxy_image}",
             "--set",
             f"values.global.proxy_init.image={global_proxy_init_image}",
+            "--set",
+            "meshConfig.accessLogFile=/dev/stdout",
         ]
 
         # The following are a set of flags that configure the CNI behaviour

--- a/charms/istio-pilot/tests/unit/test_charm.py
+++ b/charms/istio-pilot/tests/unit/test_charm.py
@@ -1323,6 +1323,8 @@ class TestCharmUpgrade:
                 "values.global.proxy.image=proxyv2",
                 "--set",
                 "values.global.proxy_init.image=proxyv2",
+                "--set",
+                "meshConfig.accessLogFile=/dev/stdout",
             ],
         )
         mocked_istioctl.upgrade.assert_called_with()


### PR DESCRIPTION
This setting allow users to access debug logs.

Fixes #370

#### Manual testing

As described in #370's description.