### PR TITLE
ci: use latest/candidate for charmcraft channel

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -63,7 +63,7 @@ jobs:
           channel: ${{ matrix.microk8s-versions }}
           microk8s-addons: "dns hostpath-storage rbac metallb:10.64.140.43-10.64.140.49"
           juju-channel: 3.1/stable
-          charmcraft-channel: latest/edge
+          charmcraft-channel: latest/candidate
   
       - name: Run integration tests
         run: |
@@ -130,7 +130,7 @@ jobs:
           channel: ${{ matrix.microk8s-versions }}
           microk8s-addons: "dns hostpath-storage rbac metallb:10.64.140.43-10.64.140.49"
           juju-channel: 3.1/stable
-          charmcraft-channel: latest/edge
+          charmcraft-channel: latest/candidate
  
       - name: Run observability integration tests
         run: |


### PR DESCRIPTION
This commit pins charmcraft to latest/candidate to avoid issues with the least stable edge channel.

This PR aims at fixing the following error:

```
charmcraft pack -v
Starting charmcraft, version 2.5.5.post96+g26e3f02                                                                                 
Logging execution to '/home/dplascen/.local/state/charmcraft/log/charmcraft-20240301-124953.845091.log'                            
Bad charmcraft.yaml content:
- ensure this value has at most 78 characters (in field 'summary')                                    
Full execution log: '/home/dplascen/.local/state/charmcraft/log/charmcraft-20240301-124953.845091.log'     
```
Which was caught in the CI of https://github.com/canonical/istio-operators/pull/386.

It would be better to pin this channel than to adapt an older version of this charm. Open to discussions.