### PR TITLE
tests: pin kubeflow-volumes to its 1.8/stable channel

### DIFF
--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -100,7 +100,8 @@ async def test_ingress_relation(ops_test: OpsTest):
     TODO (https://github.com/canonical/istio-operators/issues/259): Change this from using a
      specific charm that implements ingress's requirer interface to a generic charm
     """
-    await ops_test.model.deploy(KUBEFLOW_VOLUMES, channel="latest/edge")
+    # Use kubeflow-volumes from 1.8/stable to keep consistency between releases and the CI
+    await ops_test.model.deploy(KUBEFLOW_VOLUMES, channel="1.8/stable")
 
     await ops_test.model.add_relation(f"{ISTIO_PILOT}:ingress", f"{KUBEFLOW_VOLUMES}:ingress")
 


### PR DESCRIPTION
This charm has been refactored into a sidecar which now requires to be trusted, which makes the CI to fail because it cannot deploy this test dependency. On the other hand, the integration test execution should be kept exactly the same as when v1.17 of the istio-pilot was released, thus pinning the charm dependency is a way to keep things consistent and avoid issues.