### PR TITLE
fix: shorten the summary as a workaround for canonical/charmcraft#1568

### DIFF
--- a/charms/istio-pilot/metadata.yaml
+++ b/charms/istio-pilot/metadata.yaml
@@ -1,7 +1,5 @@
 name: istio-pilot
-summary: |
-  Istio Pilot provides fleet-wide traffic management capabilities in the
-  Istio Service Mesh.
+summary: Provides traffic management capabilities in the Istio Service Mesh.
 description: |
   https://istio.io/latest/docs/reference/commands/pilot-discovery/
 docs: https://discourse.charmhub.io/t/11837


### PR DESCRIPTION
In recent versions of charmcraft, the summary line must not exceed 78 characters. This change has been introduced in v2.5, which is heavily used by CKF charms. Since pinning the charmcraft version to an earlier release won't scale correctly, it has been decided to move on with the workaround, which aligns more to what charmcraft will expect in the future.

See canonical/charmcraft#1568 for reference.

#### Testing instructions

We must ensure that changes in this metadata won't affect upgrades.

1. Deploy `istio-operators` charms from charmhub v1.17 and relate them
2. Refresh the `istio-pilot` to the version published by this PR
3. Check for errors

> NOTES: 
1. we must change this field in `main` and `track/1.17`
2. the CI will fail because of kubeflow-volumes, #388 fixes the issue