### PR TITLE
fix: shorten the summary as a workaround for canonical/charmcraft#1568 (#389)

### DIFF
--- a/charms/istio-pilot/metadata.yaml
+++ b/charms/istio-pilot/metadata.yaml
@@ -1,7 +1,5 @@
 name: istio-pilot
-summary: |
-  Istio Pilot provides fleet-wide traffic management capabilities in the
-  Istio Service Mesh.
+summary: Provides traffic management capabilities in the Istio Service Mesh.
 description: |
   https://istio.io/latest/docs/reference/commands/pilot-discovery/
 docs: https://discourse.charmhub.io/t/11837


### PR DESCRIPTION
In recent versions of charmcraft, the summary line must not exceed 78 characters. This change has been introduced in v2.5, which is heavily used by CKF charms. Since pinning the charmcraft version to an earlier release won't scale correctly, it has been decided to move on with the workaround, which aligns more to what charmcraft will expect in the future.