### PR TITLE
fix: call self._cni_config_changed and handle exception

### DIFF
--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -288,10 +288,11 @@ class Operator(CharmBase):
         # only if the CNI configurations have been provided and have changed from a previous state
         # This is useful when there is a missing configuration during the install process
         try:
-            if self._cni_config_changed:
+            if self._cni_config_changed():
                 self.upgrade_charm(event)
         except GenericCharmRuntimeError as err:
-            handled_errors.append(err)
+            # Re-raise as there is no recovery from this error
+            raise err
 
         # Send istiod information to the istio-pilot relation
         try:

--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -287,12 +287,8 @@ class Operator(CharmBase):
         # Call upgrade_charm in case there are new configurations that affect the control plane
         # only if the CNI configurations have been provided and have changed from a previous state
         # This is useful when there is a missing configuration during the install process
-        try:
-            if self._cni_config_changed():
-                self.upgrade_charm(event)
-        except GenericCharmRuntimeError as err:
-            # Re-raise as there is no recovery from this error
-            raise err
+        if self._cni_config_changed():
+            self.upgrade_charm(event)
 
         # Send istiod information to the istio-pilot relation
         try:

--- a/charms/istio-pilot/tests/unit/test_charm.py
+++ b/charms/istio-pilot/tests/unit/test_charm.py
@@ -216,6 +216,7 @@ class TestCharmEvents:
         harness.update_config({"default-gateway": gateway_name})
 
         harness.begin()
+        harness.add_relation("peers", harness.charm.app.name)
         mocker.patch("charm.Operator.upgrade_charm")
 
         harness.charm.log = MagicMock()
@@ -293,6 +294,7 @@ class TestCharmEvents:
         harness.update_config({"default-gateway": gateway_name})
 
         harness.begin()
+        harness.add_relation("peers", harness.charm.app.name)
         mocker.patch("charm.Operator.upgrade_charm")
 
         # Do a reconcile
@@ -355,6 +357,7 @@ class TestCharmEvents:
         harness.update_config({"default-gateway": gateway_name})
 
         harness.begin()
+        harness.add_relation("peers", harness.charm.app.name)
         mocker.patch("charm.Operator.upgrade_charm")
 
         # Do a reconcile
@@ -391,6 +394,7 @@ class TestCharmEvents:
         mocked_is_gateway_service_up.return_value = True
 
         harness.begin()
+        harness.add_relation("peers", harness.charm.app.name)
         mocker.patch("charm.Operator.upgrade_charm")
 
         # Act and assert
@@ -486,6 +490,7 @@ class TestCharmHelpers:
         )
 
         harness.begin()
+        harness.add_relation("peers", harness.charm.app.name)
         mocker.patch("charm.Operator.upgrade_charm")
 
         # Act


### PR DESCRIPTION
The _cni_config_changed() method was not called correctly because of a typo, which led to the condition evaluating it to always be True, and running upgrades when they are not required. Calling correctly the method ensures the charm executes correct pieces of code.
By doing this, the GenericCharmRuntimeError exception that gets raised on an error with CNI configuration must be re-raised when handling the reconcile.

Fixes #395