### PR TITLE
feat: add action to handle SSL values as secrets for TLS configuration (#394)

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -51,7 +51,8 @@ jobs:
           - 1.26-strict/stable
         integration-types:
           - integration
-          - integration-tls
+          - integration-tls-provider
+          - integration-tls-secret
     steps:
       - name: Check out repo
         uses: actions/checkout@v3

--- a/charms/istio-pilot/actions.yaml
+++ b/charms/istio-pilot/actions.yaml
@@ -1,0 +1,26 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+set-tls:
+  description: |
+    Manually pass SSL cert and key values to configure the Ingress Gateway with TLS.
+    Configuring TLS with this action is mutually exclusive to using TLS certificate providers.
+  params:
+    ssl-key:
+      type: string
+      pattern: "^.*[a-zA-Z0-9]+.*$"
+      minLength: 1
+      description: |
+        The SSL key output as a string. Can be set with
+        $ juju run set-tls istio-pilot/<unit-number> ssl-key="$(cat KEY_FILE)"
+    ssl-crt:
+      type: string
+      minLength: 1
+      pattern: "^.*[a-zA-Z0-9]+.*$"
+      description: |
+        The SSL cert output as a string. Can be set with
+        $ juju run set-tls istio-pilot/<unit-number> ssl-crt="$(cat CERT_FILE)"
+  required: [ssl-key, ssl-crt]
+unset-tls:
+  description: Remove SSL cert and key values from the Ingress Gateway TLS configuration.
+  additionalProperties: false

--- a/tests/test_bundle_tls_provider.py
+++ b/tests/test_bundle_tls_provider.py
@@ -18,7 +18,7 @@ GATEWAY_RESOURCE = create_namespaced_resource(
 
 @pytest.fixture(scope="session")
 def lightkube_client() -> lightkube.Client:
-    client = lightkube.Client(field_manager="kserve")
+    client = lightkube.Client()
     return client
 
 

--- a/tests/test_bundle_tls_secret.py
+++ b/tests/test_bundle_tls_secret.py
@@ -1,0 +1,97 @@
+import lightkube
+import pytest
+import tenacity
+from lightkube.generic_resource import create_namespaced_resource
+from lightkube.resources.core_v1 import Secret
+from pytest_operator.plugin import OpsTest
+
+ISTIO_PILOT = "istio-pilot"
+ISTIO_GATEWAY_APP_NAME = "istio-ingressgateway"
+DEFAULT_GATEWAY_NAME = "test-gateway"
+GATEWAY_RESOURCE = create_namespaced_resource(
+    group="networking.istio.io",
+    version="v1alpha3",
+    kind="Gateway",
+    plural="gateways",
+)
+
+
+@pytest.fixture(scope="session")
+def lightkube_client() -> lightkube.Client:
+    client = lightkube.Client()
+    return client
+
+
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy_istio_charms(ops_test: OpsTest):
+    """Build and deploy istio-operators with TLS configuration."""
+    charms_path = "./charms/istio"
+    istio_charms = await ops_test.build_charms(f"{charms_path}-gateway", f"{charms_path}-pilot")
+
+    await ops_test.model.deploy(
+        istio_charms["istio-pilot"],
+        application_name=ISTIO_PILOT,
+        config={"default-gateway": DEFAULT_GATEWAY_NAME},
+        trust=True,
+    )
+
+    await ops_test.model.deploy(
+        istio_charms["istio-gateway"],
+        application_name=ISTIO_GATEWAY_APP_NAME,
+        config={"kind": "ingress"},
+        trust=True,
+    )
+
+    await ops_test.model.add_relation(
+        f"{ISTIO_PILOT}:istio-pilot", f"{ISTIO_GATEWAY_APP_NAME}:istio-pilot"
+    )
+
+    await ops_test.model.wait_for_idle(
+        status="active",
+        raise_on_blocked=False,
+        timeout=90 * 10,
+    )
+
+    await run_save_tls_secret_action(ops_test)
+
+
+@tenacity.retry(
+    stop=tenacity.stop_after_delay(50),
+    wait=tenacity.wait_exponential(multiplier=1, min=1, max=3),
+    reraise=True,
+)
+@pytest.mark.abort_on_fail
+def test_tls_configuration(lightkube_client, ops_test: OpsTest):
+    """Check the Gateway and Secret are configured with TLS."""
+    secret = lightkube_client.get(
+        Secret, f"{DEFAULT_GATEWAY_NAME}-gateway-secret", namespace=ops_test.model_name
+    )
+    gateway = lightkube_client.get(
+        GATEWAY_RESOURCE, DEFAULT_GATEWAY_NAME, namespace=ops_test.model_name
+    )
+
+    # Assert the Secret is not None and has correct values
+    assert secret is not None
+    assert secret.data["tls.crt"] is not None
+    assert secret.data["tls.key"] is not None
+    assert secret.type == "kubernetes.io/tls"
+
+    # Assert the Gateway is correctly configured
+    servers_dict = gateway.spec["servers"][0]
+    servers_dict_port = servers_dict["port"]
+    servers_dict_tls = servers_dict["tls"]
+
+    assert servers_dict_port["name"] == "https"
+    assert servers_dict_port["protocol"] == "HTTPS"
+
+    assert servers_dict_tls["mode"] == "SIMPLE"
+    assert servers_dict_tls["credentialName"] == secret.metadata.name
+
+
+async def run_save_tls_secret_action(ops_test: OpsTest):
+    """Run the save-tls-secret action."""
+    istio_pilot_unit = ops_test.model.applications[ISTIO_PILOT].units[0]
+    istio_pilot_unit_action = await istio_pilot_unit.run_action(
+        action_name="set-tls", **{"ssl-key": "key", "ssl-crt": "crt"}
+    )
+    await ops_test.model.get_action_output(action_uuid=istio_pilot_unit_action.entity_id, wait=120)

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ max-line-length = 100
 
 [tox]
 skipsdist = True
-envlist = {pilot,gateway}-{unit,lint},integration, integration-tls
+envlist = {pilot,gateway}-{unit,lint},integration, integration-tls-provider, integration-tls-secret
 
 [vars]
 all_path = {[vars]src_path} {[vars]tst_path}
@@ -69,10 +69,17 @@ commands =
 deps =
     -r requirements-integration.txt
 
-[testenv:integration-tls]
+[testenv:integration-tls-provider]
 allowlist_externals = rm
 commands =
-    pytest --show-capture=no --log-cli-level=INFO -vvs --tb=native {posargs} tests/test_bundle_tls.py
+    pytest --show-capture=no --log-cli-level=INFO -vvs --tb=native {posargs} tests/test_bundle_tls_provider.py
+deps =
+    -r requirements-integration.txt
+
+[testenv:integration-tls-secret]
+allowlist_externals = rm
+commands =
+    pytest --show-capture=no --log-cli-level=INFO -vvs --tb=native {posargs} tests/test_bundle_tls_secret.py
 deps =
     -r requirements-integration.txt
 


### PR DESCRIPTION
* feat: add action to handle SSL values as secrets for TLS configuration

This commits introduces actions that allow users to configure the TLS ingress gateway for a single host directly passing the SSL cert and key to the charm.
- save-tls-secret: allows users to pass the ssl-key and ssl-crt values, which the charm saves in a juju secret (owned by the charm) and uses them to reconcile the ingress Gateway with such information.
- remove-tls-secret: a handy action that allows users to remove the TLS secret, which in turn removes the TLS configuration from the ingress Gateway.

This commit also adds unit and integration tests to increase the coverage due to the recent changes.

WARNING: please note this feature is only supported in 1.17 and 1.18, and it will be removed after releasing 1.18 in favour of the TLS provider method.

Fixes #380