### PR TITLE
build: bump juju, ops versions in ci and requirements files

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -63,7 +63,7 @@ jobs:
           provider: microk8s
           channel: ${{ matrix.microk8s-versions }}
           microk8s-addons: "dns hostpath-storage rbac metallb:10.64.140.43-10.64.140.49"
-          juju-channel: 3.1/stable
+          juju-channel: 3/stable
           charmcraft-channel: latest/edge
   
       - name: Run integration tests
@@ -130,7 +130,7 @@ jobs:
           provider: microk8s
           channel: ${{ matrix.microk8s-versions }}
           microk8s-addons: "dns hostpath-storage rbac metallb:10.64.140.43-10.64.140.49"
-          juju-channel: 3.1/stable
+          juju-channel: 3/stable
           charmcraft-channel: latest/edge
  
       - name: Run observability integration tests

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -63,7 +63,7 @@ jobs:
           provider: microk8s
           channel: ${{ matrix.microk8s-versions }}
           microk8s-addons: "dns hostpath-storage rbac metallb:10.64.140.43-10.64.140.49"
-          juju-channel: 3/stable
+          juju-channel: 3.4/stable
           charmcraft-channel: latest/edge
   
       - name: Run integration tests
@@ -130,7 +130,7 @@ jobs:
           provider: microk8s
           channel: ${{ matrix.microk8s-versions }}
           microk8s-addons: "dns hostpath-storage rbac metallb:10.64.140.43-10.64.140.49"
-          juju-channel: 3/stable
+          juju-channel: 3.4/stable
           charmcraft-channel: latest/edge
  
       - name: Run observability integration tests

--- a/charms/istio-gateway/requirements-unit.in
+++ b/charms/istio-gateway/requirements-unit.in
@@ -1,22 +1,7 @@
-# Copyright 2023 Canonical Ltd.
-# See LICENSE file for licensing details.
-# Please note this file introduces dependencies from the charm's requirements.in,
-# special attention must be taken when updating this or the other .in file to try
-# to avoid incompatibilities.
-# Rules for editing this file:
-#   * Removing a dependency that is no longer used in the unit test file(s)
-#     is allowed, and should not represent any risk.
-#   * Adding a dependency in this file means the dependency is directly used
-#     in the unit test files(s).
-#   * ALL python packages/libs used directly in the unit test file(s) must be
-#     listed here even if requirements.in is already adding them. This will
-#     add clarity to the dependency list.
-#   * Pinning a version of a python package/lib shared with requirements.in
-#     must not introduce any incompatibilities.
 coverage
 lightkube
 ops
 pytest
 pytest-mock
 pyyaml
--r requirements.in
+-r requirements.txt

--- a/charms/istio-gateway/requirements-unit.txt
+++ b/charms/istio-gateway/requirements-unit.txt
@@ -5,66 +5,91 @@
 #    pip-compile requirements-unit.in
 #
 anyio==4.0.0
-    # via httpcore
+    # via
+    #   -r requirements.txt
+    #   httpcore
 attrs==23.1.0
-    # via jsonschema
+    # via
+    #   -r requirements.txt
+    #   jsonschema
 certifi==2023.7.22
     # via
+    #   -r requirements.txt
     #   httpcore
     #   httpx
     #   requests
 charset-normalizer==3.2.0
-    # via requests
+    # via
+    #   -r requirements.txt
+    #   requests
 coverage==7.3.0
     # via -r requirements-unit.in
 exceptiongroup==1.1.3
     # via
+    #   -r requirements.txt
     #   anyio
     #   pytest
 h11==0.14.0
-    # via httpcore
+    # via
+    #   -r requirements.txt
+    #   httpcore
 httpcore==0.17.3
-    # via httpx
+    # via
+    #   -r requirements.txt
+    #   httpx
 httpx==0.24.1
-    # via lightkube
+    # via
+    #   -r requirements.txt
+    #   lightkube
 idna==3.4
     # via
+    #   -r requirements.txt
     #   anyio
     #   httpx
     #   requests
 importlib-resources==6.0.1
-    # via jsonschema
+    # via
+    #   -r requirements.txt
+    #   jsonschema
 iniconfig==2.0.0
     # via pytest
 jinja2==3.1.2
-    # via -r requirements.in
+    # via -r requirements.txt
 jsonschema==4.17.3
-    # via serialized-data-interface
+    # via
+    #   -r requirements.txt
+    #   serialized-data-interface
 lightkube==0.14.0
     # via
     #   -r requirements-unit.in
-    #   -r requirements.in
+    #   -r requirements.txt
 lightkube-models==1.27.1.4
     # via
-    #   -r requirements.in
+    #   -r requirements.txt
     #   lightkube
 markupsafe==2.1.3
-    # via jinja2
+    # via
+    #   -r requirements.txt
+    #   jinja2
 oci-image==1.0.0
-    # via -r requirements.in
-ops==2.6.0
+    # via -r requirements.txt
+ops==2.12.0
     # via
     #   -r requirements-unit.in
-    #   -r requirements.in
+    #   -r requirements.txt
     #   serialized-data-interface
 packaging==23.1
     # via pytest
 pkgutil-resolve-name==1.3.10
-    # via jsonschema
+    # via
+    #   -r requirements.txt
+    #   jsonschema
 pluggy==1.3.0
     # via pytest
 pyrsistent==0.19.3
-    # via jsonschema
+    # via
+    #   -r requirements.txt
+    #   jsonschema
 pytest==7.4.1
     # via
     #   -r requirements-unit.in
@@ -74,25 +99,33 @@ pytest-mock==3.11.1
 pyyaml==6.0.1
     # via
     #   -r requirements-unit.in
+    #   -r requirements.txt
     #   lightkube
     #   ops
     #   serialized-data-interface
 requests==2.31.0
     # via
-    #   -r requirements.in
+    #   -r requirements.txt
     #   serialized-data-interface
 serialized-data-interface==0.7.0
-    # via -r requirements.in
+    # via -r requirements.txt
 sniffio==1.3.0
     # via
+    #   -r requirements.txt
     #   anyio
     #   httpcore
     #   httpx
 tomli==2.0.1
     # via pytest
 urllib3==2.0.4
-    # via requests
+    # via
+    #   -r requirements.txt
+    #   requests
 websocket-client==1.6.2
-    # via ops
+    # via
+    #   -r requirements.txt
+    #   ops
 zipp==3.16.2
-    # via importlib-resources
+    # via
+    #   -r requirements.txt
+    #   importlib-resources

--- a/charms/istio-gateway/requirements.txt
+++ b/charms/istio-gateway/requirements.txt
@@ -44,7 +44,7 @@ markupsafe==2.1.3
     # via jinja2
 oci-image==1.0.0
     # via -r requirements.in
-ops==2.6.0
+ops==2.12.0
     # via
     #   -r requirements.in
     #   serialized-data-interface

--- a/charms/istio-pilot/metadata.yaml
+++ b/charms/istio-pilot/metadata.yaml
@@ -102,4 +102,4 @@ peers:
   peers:
     interface: istio_pilot_peers
 assumes:
-- juju >= 3.3
+- juju >= 3.4

--- a/charms/istio-pilot/metadata.yaml
+++ b/charms/istio-pilot/metadata.yaml
@@ -102,4 +102,4 @@ peers:
   peers:
     interface: istio_pilot_peers
 assumes:
-- juju >= 2.9.0
+- juju >= 3.3

--- a/charms/istio-pilot/requirements-unit.in
+++ b/charms/istio-pilot/requirements-unit.in
@@ -1,18 +1,3 @@
-# Copyright 2023 Canonical Ltd.
-# See LICENSE file for licensing details.
-# Please note this file introduces dependencies from the charm's requirements.in,
-# special attention must be taken when updating this or the other .in file to try
-# to avoid incompatibilities.
-# Rules for editing this file:
-#   * Removing a dependency that is no longer used in the unit test file(s)
-#     is allowed, and should not represent any risk.
-#   * Adding a dependency in this file means the dependency is directly used
-#     in the unit test files(s).
-#   * ALL python packages/libs used directly in the unit test file(s) must be
-#     listed here even if requirements.in is already adding them. This will
-#     add clarity to the dependency list.
-#   * Pinning a version of a python package/lib shared with requirements.in
-#     must not introduce any incompatibilities.
 charmed-kubeflow-chisme
 coverage
 jinja2
@@ -22,7 +7,7 @@ pytest
 pytest-mock
 pyyaml
 tenacity
--r requirements.in
+-r requirements.txt
 
 # cryptography and jsonschema are required by the tls-certificates library
 # but those packages are installed from binary to avoid build time issues.

--- a/charms/istio-pilot/requirements-unit.txt
+++ b/charms/istio-pilot/requirements-unit.txt
@@ -5,11 +5,16 @@
 #    pip-compile requirements-unit.in
 #
 anyio==4.0.0
-    # via httpcore
+    # via
+    #   -r requirements.txt
+    #   httpcore
 attrs==23.1.0
-    # via jsonschema
+    # via
+    #   -r requirements.txt
+    #   jsonschema
 certifi==2023.7.22
     # via
+    #   -r requirements.txt
     #   httpcore
     #   httpx
     #   requests
@@ -18,74 +23,97 @@ cffi==1.16.0
 charmed-kubeflow-chisme==0.2.0
     # via
     #   -r requirements-unit.in
-    #   -r requirements.in
+    #   -r requirements.txt
 charset-normalizer==3.2.0
-    # via requests
+    # via
+    #   -r requirements.txt
+    #   requests
 coverage==7.3.0
     # via -r requirements-unit.in
 cryptography==41.0.4
     # via -r requirements-unit.in
 deepdiff==6.2.1
-    # via charmed-kubeflow-chisme
+    # via
+    #   -r requirements.txt
+    #   charmed-kubeflow-chisme
 exceptiongroup==1.1.3
     # via
+    #   -r requirements.txt
     #   anyio
     #   pytest
 h11==0.14.0
-    # via httpcore
+    # via
+    #   -r requirements.txt
+    #   httpcore
 httpcore==0.17.3
-    # via httpx
+    # via
+    #   -r requirements.txt
+    #   httpx
 httpx==0.24.1
-    # via lightkube
+    # via
+    #   -r requirements.txt
+    #   lightkube
 idna==3.4
     # via
+    #   -r requirements.txt
     #   anyio
     #   httpx
     #   requests
 importlib-resources==6.0.1
-    # via jsonschema
+    # via
+    #   -r requirements.txt
+    #   jsonschema
 iniconfig==2.0.0
     # via pytest
 jinja2==3.1.2
     # via
     #   -r requirements-unit.in
-    #   -r requirements.in
+    #   -r requirements.txt
     #   charmed-kubeflow-chisme
 jsonschema==4.17.3
     # via
     #   -r requirements-unit.in
+    #   -r requirements.txt
     #   serialized-data-interface
 lightkube==0.14.0
     # via
     #   -r requirements-unit.in
-    #   -r requirements.in
+    #   -r requirements.txt
     #   charmed-kubeflow-chisme
 lightkube-models==1.26.0.4
     # via
-    #   -r requirements.in
+    #   -r requirements.txt
     #   lightkube
 markupsafe==2.1.3
-    # via jinja2
-ops==2.6.0
+    # via
+    #   -r requirements.txt
+    #   jinja2
+ops==2.12.0
     # via
     #   -r requirements-unit.in
-    #   -r requirements.in
+    #   -r requirements.txt
     #   charmed-kubeflow-chisme
     #   serialized-data-interface
 ordered-set==4.1.0
-    # via deepdiff
+    # via
+    #   -r requirements.txt
+    #   deepdiff
 packaging==23.1
     # via
-    #   -r requirements.in
+    #   -r requirements.txt
     #   pytest
 pkgutil-resolve-name==1.3.10
-    # via jsonschema
+    # via
+    #   -r requirements.txt
+    #   jsonschema
 pluggy==1.3.0
     # via pytest
 pycparser==2.21
     # via cffi
 pyrsistent==0.19.3
-    # via jsonschema
+    # via
+    #   -r requirements.txt
+    #   jsonschema
 pytest==7.4.1
     # via
     #   -r requirements-unit.in
@@ -95,36 +123,48 @@ pytest-mock==3.11.1
 pyyaml==6.0.1
     # via
     #   -r requirements-unit.in
+    #   -r requirements.txt
     #   lightkube
     #   ops
     #   serialized-data-interface
 requests==2.31.0
     # via
-    #   -r requirements.in
+    #   -r requirements.txt
     #   serialized-data-interface
 ruamel-yaml==0.17.32
-    # via charmed-kubeflow-chisme
+    # via
+    #   -r requirements.txt
+    #   charmed-kubeflow-chisme
 ruamel-yaml-clib==0.2.7
-    # via ruamel-yaml
+    # via
+    #   -r requirements.txt
+    #   ruamel-yaml
 serialized-data-interface==0.7.0
     # via
-    #   -r requirements.in
+    #   -r requirements.txt
     #   charmed-kubeflow-chisme
 sniffio==1.3.0
     # via
+    #   -r requirements.txt
     #   anyio
     #   httpcore
     #   httpx
 tenacity==8.2.3
     # via
     #   -r requirements-unit.in
-    #   -r requirements.in
+    #   -r requirements.txt
     #   charmed-kubeflow-chisme
 tomli==2.0.1
     # via pytest
 urllib3==2.0.4
-    # via requests
+    # via
+    #   -r requirements.txt
+    #   requests
 websocket-client==1.6.2
-    # via ops
+    # via
+    #   -r requirements.txt
+    #   ops
 zipp==3.16.2
-    # via importlib-resources
+    # via
+    #   -r requirements.txt
+    #   importlib-resources

--- a/charms/istio-pilot/requirements.txt
+++ b/charms/istio-pilot/requirements.txt
@@ -50,7 +50,7 @@ lightkube-models==1.26.0.4
     #   lightkube
 markupsafe==2.1.3
     # via jinja2
-ops==2.6.0
+ops==2.12.0
     # via
     #   -r requirements.in
     #   charmed-kubeflow-chisme

--- a/charms/istio-pilot/tests/unit/test_charm.py
+++ b/charms/istio-pilot/tests/unit/test_charm.py
@@ -1493,6 +1493,7 @@ class TestCharmUpgrade:
         harness.begin()
         assert harness.charm._use_https_with_tls_secret() is False
 
+    @pytest.mark.skip("This test case will be removed by #401, no need to execute it.")
     def test_set_tls_set_secret_content(
         self,
         harness,
@@ -1517,6 +1518,7 @@ class TestCharmUpgrade:
             == mocked_action_event.params
         )
 
+    @pytest.mark.skip("This test case will be removed by #401, no need to execute it.")
     def test_set_tls_add_secret(
         self, harness, mocked_cert_subject, all_operator_reconcile_handlers_mocked
     ):
@@ -1534,6 +1536,7 @@ class TestCharmUpgrade:
             == mocked_action_event.params
         )
 
+    @pytest.mark.skip("This test case will be removed by #401, no need to execute it.")
     def test_unset_tls(self, harness, all_operator_reconcile_handlers_mocked, mocked_cert_subject):
         """Test the secret gets removed."""
         harness.begin()

--- a/requirements-integration.txt
+++ b/requirements-integration.txt
@@ -160,7 +160,7 @@ pytest==7.4.2
     #   pytest-operator
 pytest-asyncio==0.21.1
     # via pytest-operator
-pytest-operator==0.29.0
+pytest-operator==0.34.0
     # via -r requirements-integration.in
 python-dateutil==2.8.2
     # via kubernetes

--- a/requirements-integration.txt
+++ b/requirements-integration.txt
@@ -82,7 +82,7 @@ jedi==0.19.0
     # via ipython
 jinja2==3.1.2
     # via pytest-operator
-juju==3.2.2
+juju==3.4.0.0
     # via
     #   -r requirements-integration.in
     #   pytest-operator
@@ -109,7 +109,9 @@ oauthlib==3.2.2
     #   kubernetes
     #   requests-oauthlib
 packaging==23.1
-    # via pytest
+    # via
+    #   juju
+    #   pytest
 paramiko==2.12.0
     # via juju
 parso==0.8.3

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -19,22 +19,12 @@ from pytest_operator.plugin import OpsTest
 
 log = logging.getLogger(__name__)
 
-# Test dependencies
 DEX_AUTH = "dex-auth"
-DEX_AUTH_CHANNEL = "2.36/stable"
-TRUST_DEX_AUTH = True
 OIDC_GATEKEEPER = "oidc-gatekeeper"
-OIDC_GATEKEEPER_CHANNEL = "ckf-1.8/stable"
-TRUST_OIDC_GATEKEEPER = False
-TENSORBOARD_CONTROLLER = "tensorboard-controller"
-TENSORBOARD_CONTROLLER_CHANNEL = "1.8/stable"
-TRUST_TENSORBOARD_CONTROLLER = True
-INGRESS_REQUIRER = "kubeflow-volumes"
-INGRESS_REQUIRER_CHANNEL = "1.8/stable"
-TRUST_INGRESS_REQUIRER = True
-
 ISTIO_PILOT = "istio-pilot"
 ISTIO_GATEWAY_APP_NAME = "istio-ingressgateway"
+TENSORBOARD_CONTROLLER = "tensorboard-controller"
+KUBEFLOW_VOLUMES = "kubeflow-volumes"
 
 USERNAME = "user123"
 PASSWORD = "user123"
@@ -110,11 +100,10 @@ async def test_ingress_relation(ops_test: OpsTest):
     TODO (https://github.com/canonical/istio-operators/issues/259): Change this from using a
      specific charm that implements ingress's requirer interface to a generic charm
     """
-    await ops_test.model.deploy(
-        INGRESS_REQUIRER, channel=INGRESS_REQUIRER_CHANNEL, trust=TRUST_INGRESS_REQUIRER
-    )
+    # Use kubeflow-volumes from 1.8/stable to keep consistency between releases and the CI
+    await ops_test.model.deploy(KUBEFLOW_VOLUMES, channel="1.8/stable")
 
-    await ops_test.model.add_relation(f"{ISTIO_PILOT}:ingress", f"{INGRESS_REQUIRER}:ingress")
+    await ops_test.model.add_relation(f"{ISTIO_PILOT}:ingress", f"{KUBEFLOW_VOLUMES}:ingress")
 
     await ops_test.model.wait_for_idle(
         status="active",
@@ -122,7 +111,7 @@ async def test_ingress_relation(ops_test: OpsTest):
         timeout=90 * 10,
     )
 
-    assert_virtualservice_exists(name=INGRESS_REQUIRER, namespace=ops_test.model_name)
+    assert_virtualservice_exists(name=KUBEFLOW_VOLUMES, namespace=ops_test.model_name)
 
     # Confirm that the UI is reachable through the ingress
     gateway_ip = await get_gateway_ip(ops_test)
@@ -135,7 +124,7 @@ async def test_gateway_info_relation(ops_test: OpsTest):
     TODO (https://github.com/canonical/istio-operators/issues/259): Change this from using a
      specific charm that implements ingress's requirer interface to a generic charm
     """
-    await ops_test.model.deploy(TENSORBOARD_CONTROLLER, channel=TENSORBOARD_CONTROLLER_CHANNEL, trust=TRUST_TENSORBOARD_CONTROLLER)
+    await ops_test.model.deploy(TENSORBOARD_CONTROLLER, channel="latest/edge", trust=True)
 
     await ops_test.model.add_relation(
         f"{ISTIO_PILOT}:gateway-info", f"{TENSORBOARD_CONTROLLER}:gateway-info"
@@ -246,8 +235,8 @@ async def test_enable_ingress_auth(ops_test: OpsTest):
     regular_ingress_gateway_ip = await get_gateway_ip(ops_test)
     await ops_test.model.deploy(
         DEX_AUTH,
-        channel=DEX_AUTH_CHANNEL,
-        trust=TRUST_DEX_AUTH,
+        channel="2.31/stable",
+        trust=True,
         config={
             "static-username": USERNAME,
             "static-password": PASSWORD,
@@ -257,8 +246,7 @@ async def test_enable_ingress_auth(ops_test: OpsTest):
 
     await ops_test.model.deploy(
         OIDC_GATEKEEPER,
-        channel=OIDC_GATEKEEPER_CHANNEL,
-        trust=TRUST_OIDC_GATEKEEPER,
+        channel="ckf-1.6/stable",
         config={"public-url": regular_ingress_gateway_ip},
     )
 

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -21,6 +21,7 @@ log = logging.getLogger(__name__)
 
 DEX_AUTH = "dex-auth"
 OIDC_GATEKEEPER = "oidc-gatekeeper"
+OIDC_GATEKEEPER_CHANNEL = "ckf-1.8/stable"
 ISTIO_PILOT = "istio-pilot"
 ISTIO_GATEWAY_APP_NAME = "istio-ingressgateway"
 TENSORBOARD_CONTROLLER = "tensorboard-controller"
@@ -249,7 +250,7 @@ async def test_enable_ingress_auth(ops_test: OpsTest):
 
     await ops_test.model.deploy(
         OIDC_GATEKEEPER,
-        channel="ckf-1.8/stable",
+        channel=OIDC_GATEKEEPER_CHANNEL,
         config={"public-url": regular_ingress_gateway_ip},
     )
 

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -24,7 +24,9 @@ OIDC_GATEKEEPER = "oidc-gatekeeper"
 ISTIO_PILOT = "istio-pilot"
 ISTIO_GATEWAY_APP_NAME = "istio-ingressgateway"
 TENSORBOARD_CONTROLLER = "tensorboard-controller"
-INGRESS_REQUIRER = "tensorboards-web-app"
+INGRESS_REQUIRER = "kubeflow-volumes"
+INGRESS_REQUIRER_CHANNEL = "1.8/stable"
+TRUST_INGRESS_REQUIRER = True
 
 USERNAME = "user123"
 PASSWORD = "user123"
@@ -100,7 +102,7 @@ async def test_ingress_relation(ops_test: OpsTest):
     TODO (https://github.com/canonical/istio-operators/issues/259): Change this from using a
      specific charm that implements ingress's requirer interface to a generic charm
     """
-    await ops_test.model.deploy(INGRESS_REQUIRER, channel="1.8/stable", trust=True)
+    await ops_test.model.deploy(INGRESS_REQUIRER, channel=INGRESS_REQUIRER_CHANNEL, trust=TRUST_INGRESS_REQUIRER)
 
     await ops_test.model.add_relation(f"{ISTIO_PILOT}:ingress", f"{INGRESS_REQUIRER}:ingress")
 
@@ -114,7 +116,7 @@ async def test_ingress_relation(ops_test: OpsTest):
 
     # Confirm that the UI is reachable through the ingress
     gateway_ip = await get_gateway_ip(ops_test)
-    await assert_page_reachable(url=f"http://{gateway_ip}/tensorboards/", title="Frontend")
+    await assert_page_reachable(url=f"http://{gateway_ip}/volumes/", title="Frontend")
 
 
 async def test_gateway_info_relation(ops_test: OpsTest):

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -102,7 +102,7 @@ async def test_ingress_relation(ops_test: OpsTest):
     """
     await ops_test.model.deploy(INGRESS_REQUIRER, channel="1.8/stable", trust=True)
 
-    await ops_test.model.add_relation(f"{ISTIO_PILOT}:ingress", f"{KUBEFLOW_VOLUMES}:ingress")
+    await ops_test.model.add_relation(f"{ISTIO_PILOT}:ingress", f"{INGRESS_REQUIRER}:ingress")
 
     await ops_test.model.wait_for_idle(
         status="active",
@@ -110,7 +110,7 @@ async def test_ingress_relation(ops_test: OpsTest):
         timeout=90 * 10,
     )
 
-    assert_virtualservice_exists(name=KUBEFLOW_VOLUMES, namespace=ops_test.model_name)
+    assert_virtualservice_exists(name=INGRESS_REQUIRER, namespace=ops_test.model_name)
 
     # Confirm that the UI is reachable through the ingress
     gateway_ip = await get_gateway_ip(ops_test)

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -102,7 +102,9 @@ async def test_ingress_relation(ops_test: OpsTest):
     TODO (https://github.com/canonical/istio-operators/issues/259): Change this from using a
      specific charm that implements ingress's requirer interface to a generic charm
     """
-    await ops_test.model.deploy(INGRESS_REQUIRER, channel=INGRESS_REQUIRER_CHANNEL, trust=TRUST_INGRESS_REQUIRER)
+    await ops_test.model.deploy(
+        INGRESS_REQUIRER, channel=INGRESS_REQUIRER_CHANNEL, trust=TRUST_INGRESS_REQUIRER
+    )
 
     await ops_test.model.add_relation(f"{ISTIO_PILOT}:ingress", f"{INGRESS_REQUIRER}:ingress")
 

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -19,15 +19,22 @@ from pytest_operator.plugin import OpsTest
 
 log = logging.getLogger(__name__)
 
+# Test dependencies
 DEX_AUTH = "dex-auth"
+DEX_AUTH_CHANNEL = "2.36/stable"
+TRUST_DEX_AUTH = True
 OIDC_GATEKEEPER = "oidc-gatekeeper"
 OIDC_GATEKEEPER_CHANNEL = "ckf-1.8/stable"
-ISTIO_PILOT = "istio-pilot"
-ISTIO_GATEWAY_APP_NAME = "istio-ingressgateway"
+TRUST_OIDC_GATEKEEPER = False
 TENSORBOARD_CONTROLLER = "tensorboard-controller"
+TENSORBOARD_CONTROLLER_CHANNEL = "1.8/stable"
+TRUST_TENSORBOARD_CONTROLLER = True
 INGRESS_REQUIRER = "kubeflow-volumes"
 INGRESS_REQUIRER_CHANNEL = "1.8/stable"
 TRUST_INGRESS_REQUIRER = True
+
+ISTIO_PILOT = "istio-pilot"
+ISTIO_GATEWAY_APP_NAME = "istio-ingressgateway"
 
 USERNAME = "user123"
 PASSWORD = "user123"
@@ -128,7 +135,7 @@ async def test_gateway_info_relation(ops_test: OpsTest):
     TODO (https://github.com/canonical/istio-operators/issues/259): Change this from using a
      specific charm that implements ingress's requirer interface to a generic charm
     """
-    await ops_test.model.deploy(TENSORBOARD_CONTROLLER, channel="latest/edge", trust=True)
+    await ops_test.model.deploy(TENSORBOARD_CONTROLLER, channel=TENSORBOARD_CONTROLLER_CHANNEL, trust=TRUST_TENSORBOARD_CONTROLLER)
 
     await ops_test.model.add_relation(
         f"{ISTIO_PILOT}:gateway-info", f"{TENSORBOARD_CONTROLLER}:gateway-info"
@@ -239,8 +246,8 @@ async def test_enable_ingress_auth(ops_test: OpsTest):
     regular_ingress_gateway_ip = await get_gateway_ip(ops_test)
     await ops_test.model.deploy(
         DEX_AUTH,
-        channel="2.31/stable",
-        trust=True,
+        channel=DEX_AUTH_CHANNEL,
+        trust=TRUST_DEX_AUTH,
         config={
             "static-username": USERNAME,
             "static-password": PASSWORD,
@@ -251,6 +258,7 @@ async def test_enable_ingress_auth(ops_test: OpsTest):
     await ops_test.model.deploy(
         OIDC_GATEKEEPER,
         channel=OIDC_GATEKEEPER_CHANNEL,
+        trust=TRUST_OIDC_GATEKEEPER,
         config={"public-url": regular_ingress_gateway_ip},
     )
 

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -114,7 +114,7 @@ async def test_ingress_relation(ops_test: OpsTest):
 
     # Confirm that the UI is reachable through the ingress
     gateway_ip = await get_gateway_ip(ops_test)
-    await assert_page_reachable(url=f"http://{gateway_ip}/volumes/", title="Frontend")
+    await assert_page_reachable(url=f"http://{gateway_ip}/tensorboards/", title="Frontend")
 
 
 async def test_gateway_info_relation(ops_test: OpsTest):

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -249,7 +249,7 @@ async def test_enable_ingress_auth(ops_test: OpsTest):
 
     await ops_test.model.deploy(
         OIDC_GATEKEEPER,
-        channel="ckf-1.6/stable",
+        channel="ckf-1.8/stable",
         config={"public-url": regular_ingress_gateway_ip},
     )
 

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -24,7 +24,7 @@ OIDC_GATEKEEPER = "oidc-gatekeeper"
 ISTIO_PILOT = "istio-pilot"
 ISTIO_GATEWAY_APP_NAME = "istio-ingressgateway"
 TENSORBOARD_CONTROLLER = "tensorboard-controller"
-KUBEFLOW_VOLUMES = "kubeflow-volumes"
+INGRESS_REQUIRER = "tensorboards-web-app"
 
 USERNAME = "user123"
 PASSWORD = "user123"
@@ -100,8 +100,7 @@ async def test_ingress_relation(ops_test: OpsTest):
     TODO (https://github.com/canonical/istio-operators/issues/259): Change this from using a
      specific charm that implements ingress's requirer interface to a generic charm
     """
-    # Use kubeflow-volumes from 1.8/stable to keep consistency between releases and the CI
-    await ops_test.model.deploy(KUBEFLOW_VOLUMES, channel="1.8/stable")
+    await ops_test.model.deploy(INGRESS_REQUIRER, channel="1.8/stable", trust=True)
 
     await ops_test.model.add_relation(f"{ISTIO_PILOT}:ingress", f"{KUBEFLOW_VOLUMES}:ingress")
 


### PR DESCRIPTION
Bumping juju and ops packages to use them in newer versions of the charms, plus testing them in a CI with a more recent juju version.

This commit also skips some test cases that will be removed in a follow up commit introduced by canonical/istio-operators#401.

Part of canonical/bundle-kubeflow#859
Part of #398

#### Manual testing

1. Install juju 3.4 and bootstrap a controller with the same version for the agent
2. Deploy the charms resulting from this PR
3. Execute commands like `juju config istio-pilot default-gateway="some-name"` and `juju relate istio-pilot istio-ingressgateway`
4. Execute and upgrade from an earlier version of these charms from `track/1.17`