### PR TITLE
tests: use stable versions of COS and TLS charms

### DIFF
--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -135,7 +135,11 @@ async def test_gateway_info_relation(ops_test: OpsTest):
     TODO (https://github.com/canonical/istio-operators/issues/259): Change this from using a
      specific charm that implements ingress's requirer interface to a generic charm
     """
-    await ops_test.model.deploy(TENSORBOARD_CONTROLLER, channel=TENSORBOARD_CONTROLLER_CHANNEL, trust=TRUST_TENSORBOARD_CONTROLLER)
+    await ops_test.model.deploy(
+        TENSORBOARD_CONTROLLER,
+        channel=TENSORBOARD_CONTROLLER_CHANNEL,
+        trust=TRUST_TENSORBOARD_CONTROLLER,
+    )
 
     await ops_test.model.add_relation(
         f"{ISTIO_PILOT}:gateway-info", f"{TENSORBOARD_CONTROLLER}:gateway-info"

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -22,16 +22,16 @@ log = logging.getLogger(__name__)
 # Test dependencies
 DEX_AUTH = "dex-auth"
 DEX_AUTH_CHANNEL = "2.36/stable"
-TRUST_DEX_AUTH = True
+DEX_AUTH_TRUST = True
 OIDC_GATEKEEPER = "oidc-gatekeeper"
 OIDC_GATEKEEPER_CHANNEL = "ckf-1.8/stable"
-TRUST_OIDC_GATEKEEPER = False
+OIDC_GATEKEEPER_TRUST = False
 TENSORBOARD_CONTROLLER = "tensorboard-controller"
 TENSORBOARD_CONTROLLER_CHANNEL = "1.8/stable"
-TRUST_TENSORBOARD_CONTROLLER = True
+TENSORBOARD_CONTROLLER_TRUST = True
 INGRESS_REQUIRER = "kubeflow-volumes"
 INGRESS_REQUIRER_CHANNEL = "1.8/stable"
-TRUST_INGRESS_REQUIRER = False
+INGRESS_REQUIRER_TRUST = False
 
 ISTIO_PILOT = "istio-pilot"
 ISTIO_GATEWAY_APP_NAME = "istio-ingressgateway"
@@ -111,7 +111,7 @@ async def test_ingress_relation(ops_test: OpsTest):
      specific charm that implements ingress's requirer interface to a generic charm
     """
     await ops_test.model.deploy(
-        INGRESS_REQUIRER, channel=INGRESS_REQUIRER_CHANNEL, trust=TRUST_INGRESS_REQUIRER
+        INGRESS_REQUIRER, channel=INGRESS_REQUIRER_CHANNEL, trust=INGRESS_REQUIRER_TRUST
     )
 
     await ops_test.model.add_relation(f"{ISTIO_PILOT}:ingress", f"{INGRESS_REQUIRER}:ingress")
@@ -138,7 +138,7 @@ async def test_gateway_info_relation(ops_test: OpsTest):
     await ops_test.model.deploy(
         TENSORBOARD_CONTROLLER,
         channel=TENSORBOARD_CONTROLLER_CHANNEL,
-        trust=TRUST_TENSORBOARD_CONTROLLER,
+        trust=TENSORBOARD_CONTROLLER_TRUST,
     )
 
     await ops_test.model.add_relation(
@@ -251,7 +251,7 @@ async def test_enable_ingress_auth(ops_test: OpsTest):
     await ops_test.model.deploy(
         DEX_AUTH,
         channel=DEX_AUTH_CHANNEL,
-        trust=TRUST_DEX_AUTH,
+        trust=DEX_AUTH_TRUST,
         config={
             "static-username": USERNAME,
             "static-password": PASSWORD,
@@ -262,7 +262,7 @@ async def test_enable_ingress_auth(ops_test: OpsTest):
     await ops_test.model.deploy(
         OIDC_GATEKEEPER,
         channel=OIDC_GATEKEEPER_CHANNEL,
-        trust=TRUST_OIDC_GATEKEEPER,
+        trust=OIDC_GATEKEEPER_TRUST,
         config={"public-url": regular_ingress_gateway_ip},
     )
 

--- a/tests/test_bundle_tls_provider.py
+++ b/tests/test_bundle_tls_provider.py
@@ -15,6 +15,10 @@ GATEWAY_RESOURCE = create_namespaced_resource(
     plural="gateways",
 )
 
+SELF_SIGNED_CERTIFICATES = "self-signed-certificates"
+SELF_SIGNED_CERTIFICATES_CHANNEL = "stable"
+SELF_SIGNED_CERTIFICATES_TRUST = True
+
 
 @pytest.fixture(scope="session")
 def lightkube_client() -> lightkube.Client:
@@ -53,8 +57,8 @@ async def test_build_and_deploy_istio_charms(ops_test: OpsTest):
     )
 
     await ops_test.model.deploy(
-        "self-signed-certificates",
-        channel="edge",
+        SELF_SIGNED_CERTIFICATES,
+        channel=SELF_SIGNED_CERTIFICATES,
     )
 
     await ops_test.model.add_relation(

--- a/tests/test_bundle_tls_provider.py
+++ b/tests/test_bundle_tls_provider.py
@@ -61,7 +61,7 @@ async def test_build_and_deploy_istio_charms(ops_test: OpsTest):
     )
 
     await ops_test.model.add_relation(
-        f"{ISTIO_PILOT}:certificates", f"SELF_SIGNED_CERTIFICATES:certificates"
+        f"{ISTIO_PILOT}:certificates", f"{SELF_SIGNED_CERTIFICATES}:certificates"
     )
 
     await ops_test.model.wait_for_idle(

--- a/tests/test_bundle_tls_provider.py
+++ b/tests/test_bundle_tls_provider.py
@@ -17,7 +17,6 @@ GATEWAY_RESOURCE = create_namespaced_resource(
 
 SELF_SIGNED_CERTIFICATES = "self-signed-certificates"
 SELF_SIGNED_CERTIFICATES_CHANNEL = "latest/stable"
-SELF_SIGNED_CERTIFICATES_TRUST = True
 
 
 @pytest.fixture(scope="session")
@@ -58,11 +57,11 @@ async def test_build_and_deploy_istio_charms(ops_test: OpsTest):
 
     await ops_test.model.deploy(
         SELF_SIGNED_CERTIFICATES,
-        channel=SELF_SIGNED_CERTIFICATES,
+        channel=SELF_SIGNED_CERTIFICATES_CHANNEL,
     )
 
     await ops_test.model.add_relation(
-        f"{ISTIO_PILOT}:certificates", "self-signed-certificates:certificates"
+        f"{ISTIO_PILOT}:certificates", f"SELF_SIGNED_CERTIFICATES:certificates"
     )
 
     await ops_test.model.wait_for_idle(

--- a/tests/test_bundle_tls_provider.py
+++ b/tests/test_bundle_tls_provider.py
@@ -16,7 +16,7 @@ GATEWAY_RESOURCE = create_namespaced_resource(
 )
 
 SELF_SIGNED_CERTIFICATES = "self-signed-certificates"
-SELF_SIGNED_CERTIFICATES_CHANNEL = "stable"
+SELF_SIGNED_CERTIFICATES_CHANNEL = "latest/stable"
 SELF_SIGNED_CERTIFICATES_TRUST = True
 
 


### PR DESCRIPTION
This commit pins all charms that get deployed from Charmhub to a compatible version to the CKF 1.8 release.

Part of canonical/bundle-kubeflow#863