### PR TITLE
update integration CI to preserve charmcraft's cache between builds

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -82,7 +82,7 @@ jobs:
           key: craft-shared-cache-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}-${{ strategy.job-index }}
           restore-keys: craft-shared-cache
 
-      # DEBUG: remove this
+      # DEBUG: remove this after testing
       - name: emit charmcraft cache directory contents
         run: |
           find $CRAFT_SHARED_CACHE | wc -l
@@ -94,7 +94,7 @@ jobs:
           tox -e ${{ matrix.integration-types }} -- --model test-istio
         timeout-minutes: 80
 
-      # DEBUG: remove this
+      # DEBUG: remove this after testing
       - name: emit charmcraft cache directory contents
         run: |
           find $CRAFT_SHARED_CACHE | wc -l

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -45,6 +45,7 @@ jobs:
     name: Integration Test
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         microk8s-versions:
           - 1.25-strict/stable

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -68,24 +68,24 @@ jobs:
           juju-channel: 3.1/stable
           charmcraft-channel: latest/candidate
   
-    - name: Setup Charmcraft's cache
-      id: cache
-      uses: actions/cache@v4
-      with:
-        path: ${{ env.CRAFT_SHARED_CACHE }}
-        # Cache keys must be unique - there is no overwrite mechanic.  Add IDs to avoid this (is there a better set of IDs?)
-        # partial ref: https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
-        # To match the most recent previous cache, use restore-keys with the craft-shared-cache prefix.  This will hit the
-        # "first" match, which will be from the most recent run.  
-        # ref: https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
-        key: craft-shared-cache-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}-${{ strategy.job-index }}
-        restore-keys: craft-shared-cache
+      - name: Setup Charmcraft's cache
+        id: cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.CRAFT_SHARED_CACHE }}
+          # Cache keys must be unique - there is no overwrite mechanic.  Add IDs to avoid this (is there a better set of IDs?)
+          # partial ref: https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
+          # To match the most recent previous cache, use restore-keys with the craft-shared-cache prefix.  This will hit the
+          # "first" match, which will be from the most recent run.  
+          # ref: https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
+          key: craft-shared-cache-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}-${{ strategy.job-index }}
+          restore-keys: craft-shared-cache
 
-    # DEBUG: remove this
-    - name: emit charmcraft cache directory contents
-      run: |
-        find $CRAFT_SHARED_CACHE | wc -l
-        find $CRAFT_SHARED_CACHE/wheels | wc -l
+      # DEBUG: remove this
+      - name: emit charmcraft cache directory contents
+        run: |
+          find $CRAFT_SHARED_CACHE | wc -l
+          find $CRAFT_SHARED_CACHE/wheels | wc -l
 
       - name: Run integration tests
         run: |
@@ -93,20 +93,20 @@ jobs:
           tox -e ${{ matrix.integration-types }} -- --model test-istio
         timeout-minutes: 80
 
-    # DEBUG: remove this
-    - name: emit charmcraft cache directory contents
-      run: |
-        find $CRAFT_SHARED_CACHE | wc -l
-        find $CRAFT_SHARED_CACHE/wheels | wc -l
-  
-      - name: Setup Debug Artifact Collection
-        run: mkdir tmp
-        if: failure()
-  
-      - name: Collect charmcraft logs
-        if: failure()
+      # DEBUG: remove this
+      - name: emit charmcraft cache directory contents
         run: |
-          cat /home/runner/.local/state/charmcraft/log/charmcraft-*.log | tee tmp/charmcraft.log
+          find $CRAFT_SHARED_CACHE | wc -l
+          find $CRAFT_SHARED_CACHE/wheels | wc -l
+    
+        - name: Setup Debug Artifact Collection
+          run: mkdir tmp
+          if: failure()
+    
+        - name: Collect charmcraft logs
+          if: failure()
+          run: |
+            cat /home/runner/.local/state/charmcraft/log/charmcraft-*.log | tee tmp/charmcraft.log
   
       - name: Collect Juju status
         if: failure()

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -82,7 +82,7 @@ jobs:
         restore-keys: craft-shared-cache
 
     # DEBUG: remove this
-    - name: emit pip cache directory contents
+    - name: emit charmcraft cache directory contents
       run: |
         find $CRAFT_SHARED_CACHE | wc -l
         find $CRAFT_SHARED_CACHE/wheels | wc -l
@@ -94,7 +94,7 @@ jobs:
         timeout-minutes: 80
 
     # DEBUG: remove this
-    - name: emit pip cache directory contents
+    - name: emit charmcraft cache directory contents
       run: |
         find $CRAFT_SHARED_CACHE | wc -l
         find $CRAFT_SHARED_CACHE/wheels | wc -l

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -55,7 +55,7 @@ jobs:
           - integration-tls-provider
           - integration-tls-secret
     env:
-      CRAFT_SHARED_CACHE: /home/runner/.cache/shared_charmcraft_cache
+      CRAFT_SHARED_CACHE: /home/runner/snap/charmcraft/common/cache/charmcraft/
     steps:
       - name: Check out repo
         uses: actions/checkout@v4

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -99,14 +99,14 @@ jobs:
           find $CRAFT_SHARED_CACHE | wc -l
           find $CRAFT_SHARED_CACHE/wheels | wc -l
     
-        - name: Setup Debug Artifact Collection
-          run: mkdir tmp
-          if: failure()
-    
-        - name: Collect charmcraft logs
-          if: failure()
-          run: |
-            cat /home/runner/.local/state/charmcraft/log/charmcraft-*.log | tee tmp/charmcraft.log
+      - name: Setup Debug Artifact Collection
+        run: mkdir tmp
+        if: failure()
+  
+      - name: Collect charmcraft logs
+        if: failure()
+        run: |
+          cat /home/runner/.local/state/charmcraft/log/charmcraft-*.log | tee tmp/charmcraft.log
   
       - name: Collect Juju status
         if: failure()

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -53,6 +53,8 @@ jobs:
           - integration
           - integration-tls-provider
           - integration-tls-secret
+    env:
+      CRAFT_SHARED_CACHE: /home/runner/.cache/shared_charmcraft_cache
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
@@ -66,11 +68,36 @@ jobs:
           juju-channel: 3.1/stable
           charmcraft-channel: latest/candidate
   
+    - name: Setup Charmcraft's cache
+      id: cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ env.CRAFT_SHARED_CACHE }}
+        # Cache keys must be unique - there is no overwrite mechanic.  Add IDs to avoid this (is there a better set of IDs?)
+        # partial ref: https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache
+        # To match the most recent previous cache, use restore-keys with the craft-shared-cache prefix.  This will hit the
+        # "first" match, which will be from the most recent run.  
+        # ref: https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
+        key: craft-shared-cache-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}-${{ strategy.job-index }}
+        restore-keys: craft-shared-cache
+
+    # DEBUG: remove this
+    - name: emit pip cache directory contents
+      run: |
+        find $CRAFT_SHARED_CACHE | wc -l
+        find $CRAFT_SHARED_CACHE/wheels | wc -l
+
       - name: Run integration tests
         run: |
           juju add-model test-istio
           tox -e ${{ matrix.integration-types }} -- --model test-istio
         timeout-minutes: 80
+
+    # DEBUG: remove this
+    - name: emit pip cache directory contents
+      run: |
+        find $CRAFT_SHARED_CACHE | wc -l
+        find $CRAFT_SHARED_CACHE/wheels | wc -l
   
       - name: Setup Debug Artifact Collection
         run: mkdir tmp


### PR DESCRIPTION
Attempting to save the charmcraft cache between builds, as prototyped here: https://github.com/ca-scribner/charm-cache-test
