### PR TITLE
fix: check routes before popping values

### DIFF
--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -607,7 +607,7 @@ class Operator(CharmBase):
                     f" is not in routes.keys='{list(routes.keys())}'."
                 )
             elif routes:
-                routes.pop((event.relation, event.app))
+                routes.pop((event.relation, event.app), None)
 
         return routes
 

--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -606,7 +606,7 @@ class Operator(CharmBase):
                     f" departing application's name.  We assume that the departing application's"
                     f" is not in routes.keys='{list(routes.keys())}'."
                 )
-            else:
+            elif routes:
                 routes.pop((event.relation, event.app))
 
         return routes


### PR DESCRIPTION
This commit ensures the istio-pilot charm checks that the ingress routes dictionary it uses for reconciling VirtualServices from requirers is not empty and the relation data for the departing application is there before attempting to pop values during a RelationBroken event.

Fixes #423

#### Testing

1. Follow the steps to reproduce in #423 to ensure the issue is happening
2. Remove the charm and re-deploy it from this PR
3. Try the steps in #423 again and make sure there is no error