### PR TITLE
chore: use assumes juju 3.1 instead of 3.5

### DIFF
--- a/charms/istio-gateway/metadata.yaml
+++ b/charms/istio-gateway/metadata.yaml
@@ -23,4 +23,4 @@ requires:
     versions: [v1]
     __schema_source: https://raw.githubusercontent.com/canonical/operator-schemas/master/k8s-service.yaml
 assumes:
-- juju >= 2.9.0
+- juju >= 3.1

--- a/charms/istio-pilot/metadata.yaml
+++ b/charms/istio-pilot/metadata.yaml
@@ -102,4 +102,4 @@ peers:
   peers:
     interface: istio_pilot_peers
 assumes:
-- juju >= 3.5
+- juju >= 3.1


### PR DESCRIPTION
We must ensure we do not break the deployment of existing users with a hard requirement on juju 3.5. Since in our documentation the least supported juju version is 3.1, we should reflect that also in these charms. The only scenario where people are required to bump juju to 3.4 or greater is when they want to set the TLS ingress gateway with secrets, but this is documented in a public guide.