### PR TITLE
feat, chore: add support for istio 1.22.0 and assume juju 3.1

### DIFF
--- a/charms/istio-gateway/config.yaml
+++ b/charms/istio-gateway/config.yaml
@@ -9,6 +9,6 @@ options:
     description: |
       Type of service for the ingress gateway out of: 'ClusterIP', 'LoadBalancer', or 'NodePort'.
   proxy-image:
-    default: 'docker.io/istio/proxyv2:1.17.3'
+    default: 'docker.io/istio/proxyv2:1.22.0'
     description: Istio Proxy image
     type: string

--- a/charms/istio-gateway/metadata.yaml
+++ b/charms/istio-gateway/metadata.yaml
@@ -23,4 +23,4 @@ requires:
     versions: [v1]
     __schema_source: https://raw.githubusercontent.com/canonical/operator-schemas/master/k8s-service.yaml
 assumes:
-- juju >= 2.9.0
+- juju >= 3.1

--- a/charms/istio-gateway/tests/unit/data/egress-example.yaml
+++ b/charms/istio-gateway/tests/unit/data/egress-example.yaml
@@ -115,7 +115,7 @@ spec:
               value: standard
             - name: ISTIO_META_CLUSTER_ID
               value: Kubernetes
-          image: docker.io/istio/proxyv2:1.17.3
+          image: docker.io/istio/proxyv2:1.22.0
           name: istio-proxy
           ports:
             - containerPort: 15021

--- a/charms/istio-gateway/tests/unit/data/ingress-example.yaml
+++ b/charms/istio-gateway/tests/unit/data/ingress-example.yaml
@@ -115,7 +115,7 @@ spec:
               value: standard
             - name: ISTIO_META_CLUSTER_ID
               value: Kubernetes
-          image: docker.io/istio/proxyv2:1.17.3
+          image: docker.io/istio/proxyv2:1.22.0
           name: istio-proxy
           ports:
             - containerPort: 15021

--- a/charms/istio-pilot/charmcraft.yaml
+++ b/charms/istio-pilot/charmcraft.yaml
@@ -12,5 +12,5 @@ parts:
     build-packages: [git, rustc, cargo, libffi-dev, libssl-dev, pkg-config]
   istioctl:
     plugin: dump
-    source: https://github.com/istio/istio/releases/download/1.17.3/istioctl-1.17.3-linux-amd64.tar.gz
+    source: https://github.com/istio/istio/releases/download/1.22.0/istioctl-1.22.0-linux-amd64.tar.gz
     source-type: tar

--- a/charms/istio-pilot/config.yaml
+++ b/charms/istio-pilot/config.yaml
@@ -25,7 +25,7 @@ options:
   image-configuration:
     default: |
       pilot-image: 'pilot'  # values.pilot.image
-      global-tag: '1.17.3'  # values.global.tag
+      global-tag: '1.22.0'  # values.global.tag
       global-hub: 'docker.io/istio' # values.global.hub
       global-proxy-image: 'proxyv2' # values.global.proxy.image
       global-proxy-init-image: 'proxyv2' # values.global.proxy_init.image

--- a/charms/istio-pilot/metadata.yaml
+++ b/charms/istio-pilot/metadata.yaml
@@ -102,4 +102,4 @@ peers:
   peers:
     interface: istio_pilot_peers
 assumes:
-- juju >= 3.5
+- juju >= 3.1

--- a/charms/istio-pilot/src/istioctl.py
+++ b/charms/istio-pilot/src/istioctl.py
@@ -122,7 +122,6 @@ class Istioctl:
             subprocess.check_call(
                 [
                     self._istioctl_path,
-                    "x",
                     "uninstall",
                     "--purge",
                     "-y",

--- a/charms/istio-pilot/tests/unit/test_charm.py
+++ b/charms/istio-pilot/tests/unit/test_charm.py
@@ -1357,6 +1357,8 @@ class TestCharmUpgrade:
         harness.charm.upgrade_charm("mock_event")
 
         # Assert that the upgrade was successful
+        image_config = yaml.safe_load(harness.model.config["image-configuration"])
+        pilot_image_tag = image_config["global-tag"]
         mocked_istioctl_class.assert_called_with(
             "./istioctl",
             model_name,
@@ -1365,7 +1367,7 @@ class TestCharmUpgrade:
                 "--set",
                 "values.pilot.image=pilot",
                 "--set",
-                "values.global.tag=1.17.3",
+                f"values.global.tag={pilot_image_tag}",
                 "--set",
                 "values.global.hub=docker.io/istio",
                 "--set",

--- a/charms/istio-pilot/tests/unit/test_istioctl.py
+++ b/charms/istio-pilot/tests/unit/test_istioctl.py
@@ -152,7 +152,7 @@ def test_istioctl_remove(mocked_check_call):
 
     ictl.remove()
 
-    mocked_check_call.assert_called_once_with([ISTIOCTL_BINARY, "x", "uninstall", "--purge", "-y"])
+    mocked_check_call.assert_called_once_with([ISTIOCTL_BINARY, "uninstall", "--purge", "-y"])
 
 
 def test_istioctl_remove_error(mocked_check_call_failing):

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -35,7 +35,7 @@ INGRESS_REQUIRER_TRUST = True
 
 ISTIO_PILOT = "istio-pilot"
 ISTIO_GATEWAY_APP_NAME = "istio-ingressgateway"
-
+ISTIO_RELEASE = "release-1.22"
 USERNAME = "user123"
 PASSWORD = "user123"
 
@@ -156,7 +156,7 @@ async def test_gateway_info_relation(ops_test: OpsTest):
 
 @pytest.mark.abort_on_fail
 async def test_deploy_bookinfo_example(ops_test: OpsTest):
-    root_url = "https://raw.githubusercontent.com/istio/istio/release-1.11/samples/bookinfo"
+    root_url = f"https://raw.githubusercontent.com/istio/istio/{ISTIO_RELEASE}/samples/bookinfo"
     bookinfo_namespace = f"{ops_test.model_name}-bookinfo"
 
     await ops_test.run(


### PR DESCRIPTION
This PR forward ports the following changes:

* feat: add support for istio 1.22.0 (#427)
* chore: use assumes juju 3.1 instead of 3.5 (#436)