### PR TITLE
fix: remove default nodeAffinity configurations

### DIFF
--- a/charms/istio-gateway/src/manifest.yaml
+++ b/charms/istio-gateway/src/manifest.yaml
@@ -55,37 +55,8 @@ spec:
     spec:
       affinity:
         nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - preference:
-                matchExpressions:
-                  - key: kubernetes.io/arch
-                    operator: In
-                    values:
-                      - amd64
-              weight: 2
-            - preference:
-                matchExpressions:
-                  - key: kubernetes.io/arch
-                    operator: In
-                    values:
-                      - ppc64le
-              weight: 2
-            - preference:
-                matchExpressions:
-                  - key: kubernetes.io/arch
-                    operator: In
-                    values:
-                      - s390x
-              weight: 2
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: kubernetes.io/arch
-                    operator: In
-                    values:
-                      - amd64
-                      - ppc64le
-                      - s390x
+          preferredDuringSchedulingIgnoredDuringExecution: null
+          requiredDuringSchedulingIgnoredDuringExecution: null
       containers:
         - args:
             - proxy

--- a/charms/istio-gateway/tests/unit/data/egress-example.yaml
+++ b/charms/istio-gateway/tests/unit/data/egress-example.yaml
@@ -54,37 +54,8 @@ spec:
     spec:
       affinity:
         nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - preference:
-                matchExpressions:
-                  - key: kubernetes.io/arch
-                    operator: In
-                    values:
-                      - amd64
-              weight: 2
-            - preference:
-                matchExpressions:
-                  - key: kubernetes.io/arch
-                    operator: In
-                    values:
-                      - ppc64le
-              weight: 2
-            - preference:
-                matchExpressions:
-                  - key: kubernetes.io/arch
-                    operator: In
-                    values:
-                      - s390x
-              weight: 2
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: kubernetes.io/arch
-                    operator: In
-                    values:
-                      - amd64
-                      - ppc64le
-                      - s390x
+          preferredDuringSchedulingIgnoredDuringExecution: null
+          requiredDuringSchedulingIgnoredDuringExecution: null
       containers:
         - args:
             - proxy

--- a/charms/istio-gateway/tests/unit/data/ingress-example.yaml
+++ b/charms/istio-gateway/tests/unit/data/ingress-example.yaml
@@ -54,37 +54,8 @@ spec:
     spec:
       affinity:
         nodeAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - preference:
-                matchExpressions:
-                  - key: kubernetes.io/arch
-                    operator: In
-                    values:
-                      - amd64
-              weight: 2
-            - preference:
-                matchExpressions:
-                  - key: kubernetes.io/arch
-                    operator: In
-                    values:
-                      - ppc64le
-              weight: 2
-            - preference:
-                matchExpressions:
-                  - key: kubernetes.io/arch
-                    operator: In
-                    values:
-                      - s390x
-              weight: 2
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: kubernetes.io/arch
-                    operator: In
-                    values:
-                      - amd64
-                      - ppc64le
-                      - s390x
+          preferredDuringSchedulingIgnoredDuringExecution: null
+          requiredDuringSchedulingIgnoredDuringExecution: null
       containers:
         - args:
             - proxy


### PR DESCRIPTION
The default values of the nodeAffinity field were causing this charm to cause undesired behaviours when trying to replace them (either manually or via the namespace-node-affinity charm. This commit removes those defaults from istio-gateway 1.16, newer versions of this charm do not present this issue.

Fixes #426

#### Testing

1. [Create a microk8s cluster](https://microk8s.io/docs/clustering) (2 worker nodes, 1 admin node). You can do it with [LXD containers](https://microk8s.io/docs/install-lxd).
2. Label one of the nodes with an obvious label, it can be `kubectl label node workload=istio-deploys-here`
3. For testing purposes, the admin node will also have a juju controller bootstrapped inside, but this can be done using a controller bootstrapped elsewhere.
4. Add a model `istio-test` and label it with `kubectl label ns testing-ns-a namespace-node-affinity=enabled`, this is a requirement from the `namespace-node-affinity` charm.
5. Deploy namespace-node-affinity `juju deploy namespace-node-affinity --channel 2.2/stable --trust`.
6. Deploy the `istio-operators` from this PR (you can use the [published](https://github.com/canonical/istio-operators/actions/runs/9400421611/job/25890004228#step:5:15) charms)
7. Observe that the `istio-ingressgateway-workload-xxxx-yyyy` container gets scheduled in a random node with no specific criteria.
8. Create a configuration file for passing as configuration to the `namespace-node-affinity`:

```
root@microk8s-admin:~# cat settings.yaml 
istio-test: |
  nodeSelectorTerms:
    - matchExpressions:
      - key: workload
        operator: In
        values:
        - istio-deploys-here
```
9. Pass the configuration file as config to the `namespace-node-affinity`:

```
SETTINGS_YAML=$(cat settings.yaml)
juju config namespace-node-affinity settings_yaml="$SETTINGS_YAML"
```
10. Wait for everything to get active and idle
11. Remove the `istio-ingressgateway-workload-xxxx-yyyy` `Pod` from the namespace and wait for it to be scheduled again.
12. The `Pod` should now be scheduled in the labeled `Node` that was specified in the `nodeSelectorTerms` from step 8.