### PR TITLE
tests: point all the integration charm deps to their 1.7 versions

### DIFF
--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -19,12 +19,22 @@ import tenacity
 
 log = logging.getLogger(__name__)
 
+# Test dependencies
 DEX_AUTH = "dex-auth"
+DEX_AUTH_CHANNEL = "2.31/stable"
+TRUST_DEX_AUTH = True
 OIDC_GATEKEEPER = "oidc-gatekeeper"
+OIDC_GATEKEEPER_CHANNEL = "ckf-1.7/stable"
+TRUST_OIDC_GATEKEEPER = False
+TENSORBOARD_CONTROLLER = "tensorboard-controller"
+TENSORBOARD_CONTROLLER_CHANNEL = "1.7/stable"
+TRUST_TENSORBOARD_CONTROLLER = False
+INGRESS_REQUIRER = "kubeflow-volumes"
+INGRESS_REQUIRER_CHANNEL = "1.7/stable"
+TRUST_INGRESS_REQUIRER = False
+
 ISTIO_PILOT = "istio-pilot"
 ISTIO_GATEWAY_APP_NAME = "istio-ingressgateway"
-TENSORBOARD_CONTROLLER = "tensorboard-controller"
-KUBEFLOW_VOLUMES = "kubeflow-volumes"
 
 USERNAME = "user123"
 PASSWORD = "user123"
@@ -100,9 +110,11 @@ async def test_ingress_relation(ops_test: OpsTest):
     TODO (https://github.com/canonical/istio-operators/issues/259): Change this from using a
      specific charm that implements ingress's requirer interface to a generic charm
     """
-    await ops_test.model.deploy(KUBEFLOW_VOLUMES, channel="latest/edge")
+    await ops_test.model.deploy(
+        INGRESS_REQUIRER, channel=INGRESS_REQUIRER_CHANNEL, trust=TRUST_INGRESS_REQUIRER
+    )
 
-    await ops_test.model.add_relation(f"{ISTIO_PILOT}:ingress", f"{KUBEFLOW_VOLUMES}:ingress")
+    await ops_test.model.add_relation(f"{ISTIO_PILOT}:ingress", f"{INGRESS_REQUIRER}:ingress")
 
     # TODO: This does not wait properly - it should wait for tensorboards_web_app to be active
     #  and idle.  the wait_for_idle print statements say tensorboards-web-app is active/idle, but
@@ -114,9 +126,8 @@ async def test_ingress_relation(ops_test: OpsTest):
         timeout=90 * 10,
     )
 
-    assert_application_and_units_active_idle(ops_test.model.applications[KUBEFLOW_VOLUMES])
-
-    assert_virtualservice_exists(name=KUBEFLOW_VOLUMES, namespace=ops_test.model_name)
+    assert_application_and_units_active_idle(ops_test.model.applications[INGRESS_REQUIRER])
+    assert_virtualservice_exists(name=INGRESS_REQUIRER, namespace=ops_test.model_name)
 
     # Confirm that the UI is reachable through the ingress
     gateway_ip = await get_gateway_ip(ops_test)
@@ -129,7 +140,11 @@ async def test_gateway_info_relation(ops_test: OpsTest):
     TODO (https://github.com/canonical/istio-operators/issues/259): Change this from using a
      specific charm that implements ingress's requirer interface to a generic charm
     """
-    await ops_test.model.deploy(TENSORBOARD_CONTROLLER, channel="latest/edge", trust=True)
+    await ops_test.model.deploy(
+        TENSORBOARD_CONTROLLER,
+        channel=TENSORBOARD_CONTROLLER_CHANNEL,
+        trust=TRUST_TENSORBOARD_CONTROLLER,
+    )
 
     await ops_test.model.add_relation(
         f"{ISTIO_PILOT}:gateway-info", f"{TENSORBOARD_CONTROLLER}:gateway-info"
@@ -242,8 +257,8 @@ async def test_enable_ingress_auth(ops_test: OpsTest):
     regular_ingress_gateway_ip = await get_gateway_ip(ops_test)
     await ops_test.model.deploy(
         DEX_AUTH,
-        channel="2.31/stable",
-        trust=True,
+        channel=DEX_AUTH_CHANNEL,
+        trust=TRUST_DEX_AUTH,
         config={
             "static-username": USERNAME,
             "static-password": PASSWORD,
@@ -253,7 +268,8 @@ async def test_enable_ingress_auth(ops_test: OpsTest):
 
     await ops_test.model.deploy(
         OIDC_GATEKEEPER,
-        channel="ckf-1.6/stable",
+        channel=OIDC_GATEKEEPER_CHANNEL,
+        trust=TRUST_OIDC_GATEKEEPER,
         config={"public-url": regular_ingress_gateway_ip},
     )
 


### PR DESCRIPTION
The integration tests were deploying versions of dependency charms that do not correspond to the current release of the istio-operators. This commit brings all the correct versions and configure charms accordingly to ensure the integration tests execute in the same environment as this version of the istio-operators were design for.