### PR TITLE
ci: bump microk8s 1.26(lower) and 1.29(upper)

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -47,8 +47,8 @@ jobs:
     strategy:
       matrix:
         microk8s-versions:
-          - 1.25-strict/stable
           - 1.26-strict/stable
+          - 1.29-strict/stable
         integration-types:
           - integration
           - integration-tls-provider


### PR DESCRIPTION
Based on Istio's [supported versions](https://istio.io/latest/docs/releases/supported-releases/#support-status-of-istio-releases)
Part of canonical/bundle-kubeflow#903