### PR TITLE
ci: bump microk8s 1.24(lower) and 1.27(upper)

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -47,8 +47,8 @@ jobs:
     strategy:
       matrix:
         microk8s-versions:
-          - 1.25-strict/stable
-          - 1.26-strict/stable
+          - 1.24-strict/stable
+          - 1.27-strict/stable
         integration-types:
           - integration
           - integration-tls-provider

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         microk8s-versions:
-          - 1.24-strict/stable
+          - 1.25-strict/stable
           - 1.27-strict/stable
         integration-types:
           - integration


### PR DESCRIPTION
Based on Istio's [supported versions](https://istio.io/latest/docs/releases/supported-releases/#support-status-of-istio-releases)
Part of canonical/bundle-kubeflow#903