### PR TITLE
ci: use juju 3.4/stable instead of 3.5/stable in track 1.22

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -63,7 +63,7 @@ jobs:
           provider: microk8s
           channel: ${{ matrix.microk8s-versions }}
           microk8s-addons: "dns hostpath-storage rbac metallb:10.64.140.43-10.64.140.49"
-          juju-channel: 3.5/stable
+          juju-channel: 3.4/stable
           charmcraft-channel: latest/candidate
   
       - name: Run integration tests
@@ -130,7 +130,7 @@ jobs:
           provider: microk8s
           channel: ${{ matrix.microk8s-versions }}
           microk8s-addons: "dns hostpath-storage rbac metallb:10.64.140.43-10.64.140.49"
-          juju-channel: 3.5/stable
+          juju-channel: 3.4/stable
           charmcraft-channel: latest/candidate
  
       - name: Run observability integration tests


### PR DESCRIPTION
Part of canonical/bundle-kubeflow#944