### PR TITLE
Cherry-pick `4b86064` for having mesh logs in sidecars

### DIFF
--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -211,6 +211,7 @@ class Operator(CharmBase):
 
         # Extra flags to pass to the istioctl install command
         # These flags will configure the container images used by the control plane
+        # As well as set the access log files for help during debugging
         extra_flags = [
             "--set",
             f"values.pilot.image={pilot_image}",
@@ -222,6 +223,8 @@ class Operator(CharmBase):
             f"values.global.proxy.image={global_proxy_image}",
             "--set",
             f"values.global.proxy_init.image={global_proxy_init_image}",
+            "--set",
+            "meshConfig.accessLogFile=/dev/stdout",
         ]
 
         # The following are a set of flags that configure the CNI behaviour

--- a/charms/istio-pilot/tests/unit/test_charm.py
+++ b/charms/istio-pilot/tests/unit/test_charm.py
@@ -1372,6 +1372,8 @@ class TestCharmUpgrade:
                 "values.global.proxy.image=proxyv2",
                 "--set",
                 "values.global.proxy_init.image=proxyv2",
+                "--set",
+                "meshConfig.accessLogFile=/dev/stdout",
             ],
         )
         mocked_istioctl.upgrade.assert_called_with()


### PR DESCRIPTION
Cherry-picks 4b86064 into Istio used by CKF 1.8

This will be needed to improve the debugging experience in CKF 1.8