### PR TITLE
tests: remove public-url config and add dex-oidc-config relation

### DIFF
--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -255,7 +255,6 @@ async def test_enable_ingress_auth(ops_test: OpsTest):
         config={
             "static-username": USERNAME,
             "static-password": PASSWORD,
-            "public-url": regular_ingress_gateway_ip,
         },
     )
 
@@ -263,12 +262,12 @@ async def test_enable_ingress_auth(ops_test: OpsTest):
         OIDC_GATEKEEPER,
         channel=OIDC_GATEKEEPER_CHANNEL,
         trust=OIDC_GATEKEEPER_TRUST,
-        config={"public-url": regular_ingress_gateway_ip},
     )
 
     await ops_test.model.add_relation(f"{ISTIO_PILOT}:ingress", f"{DEX_AUTH}:ingress")
     await ops_test.model.add_relation(f"{ISTIO_PILOT}:ingress", f"{OIDC_GATEKEEPER}:ingress")
     await ops_test.model.add_relation(f"{OIDC_GATEKEEPER}:oidc-client", f"{DEX_AUTH}:oidc-client")
+    await ops_test.model.add_relation(f"{OIDC_GATEKEEPER}:dex-oidc-config", f"{DEX_AUTH}:dex-oidc-config")
     await ops_test.model.add_relation(
         f"{ISTIO_PILOT}:ingress-auth", f"{OIDC_GATEKEEPER}:ingress-auth"
     )


### PR DESCRIPTION
The public-url configuration option has been replaced by a relation between dex-auth and oidc-gatekeeper. Because of that, configuring this option is not required anymore, and in fact if kept, can cause errors as it won't be recognised by Juju anymore. This commit removes the extra configuration from the integration tests.

Part of #487