### PR TITLE
fix(ci): use charmcraft from latest/candidate in integration tests

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -64,7 +64,7 @@ jobs:
           channel: ${{ matrix.microk8s-versions }}
           microk8s-addons: "dns hostpath-storage rbac metallb:10.64.140.43-10.64.140.49"
           juju-channel: 3.4/stable
-          charmcraft-channel: latest/edge
+          charmcraft-channel: latest/candidate
   
       - name: Run integration tests
         run: |
@@ -131,7 +131,7 @@ jobs:
           channel: ${{ matrix.microk8s-versions }}
           microk8s-addons: "dns hostpath-storage rbac metallb:10.64.140.43-10.64.140.49"
           juju-channel: 3.4/stable
-          charmcraft-channel: latest/edge
+          charmcraft-channel: latest/candidate
  
       - name: Run observability integration tests
         run: |


### PR DESCRIPTION
Temporary workaround for https://github.com/canonical/bundle-kubeflow/issues/1005.

The dev branch will be merged to `track/1.17` after merging also https://github.com/canonical/istio-operators/pull/526.