### PR TITLE
Pin charmcraft channel to `3.1/stable`

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -72,7 +72,7 @@ jobs:
           channel: ${{ matrix.microk8s-versions }}
           microk8s-addons: "dns hostpath-storage rbac metallb:10.64.140.43-10.64.140.49"
           juju-channel: 3.4/stable
-          charmcraft-channel: latest/candidate
+          charmcraft-channel: 3.1/stable
 
       - name: Run integration tests
         run: |
@@ -139,7 +139,7 @@ jobs:
           channel: ${{ matrix.microk8s-versions }}
           microk8s-addons: "dns hostpath-storage rbac metallb:10.64.140.43-10.64.140.49"
           juju-channel: 3.4/stable
-          charmcraft-channel: latest/candidate
+          charmcraft-channel: 3.1/stable
 
       - name: Run observability integration tests
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -91,4 +91,4 @@ jobs:
           charm-path: ${{ matrix.charm-path }}
           channel: ${{ steps.parse-inputs.outputs.destination_channel }}
           tag-prefix: ${{ steps.parse-inputs.outputs.tag_prefix }}
-          charmcraft-channel: latest/candidate
+          charmcraft-channel: 3.1/stable


### PR DESCRIPTION
This PR is part of closing [this issue](https://github.com/canonical/bundle-kubeflow/issues/1049).

It pins the channel used in our CI from `latest/candidate` to `latest/stable`.

Ideally we can unpin the version when [this issue](https://github.com/canonical/charmcraft/issues/1845) is fixed.