### PR TITLE
Fix tag istio-pilot dashboard tag

### DIFF
--- a/charms/istio-pilot/src/grafana_dashboards/istio_control_plane.json.tmpl
+++ b/charms/istio-pilot/src/grafana_dashboards/istio_control_plane.json.tmpl
@@ -1949,7 +1949,7 @@
   "schemaVersion": 38,
   "style": "dark",
   "tags": [
-    "CKF",
+    "ckf",
     "istio"
   ],
   "templating": {


### PR DESCRIPTION
Fix the CKF tag for istio-pilot dashboard. This tag should be lowercase and not upper case.

How to test this:
1. `tox -e cos-integration -- --keep-models`
2. Follow [guide](https://charmhub.io/topics/canonical-observability-stack/tutorials/install-microk8s#heading--deploy-the-cos-lite-bundle) to deploy COS.
3. Follow [guide](https://charmed-kubeflow.io/docs/integrate-with-cos) how integrate consume relation from COS.

fixes: #538