### PR TITLE
chore(backport-1.22): Pin charmcraft channel to `3.x/stable`

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -72,7 +72,8 @@ jobs:
           channel: ${{ matrix.microk8s-versions }}
           microk8s-addons: "dns hostpath-storage rbac metallb:10.64.140.43-10.64.140.49"
           juju-channel: 3.4/stable
-          charmcraft-channel: latest/candidate
+          # Pinned to 3.x/stable due to https://github.com/canonical/charmcraft/issues/1845
+          charmcraft-channel: 3.x/stable
 
       - name: Run integration tests
         run: |
@@ -139,7 +140,8 @@ jobs:
           channel: ${{ matrix.microk8s-versions }}
           microk8s-addons: "dns hostpath-storage rbac metallb:10.64.140.43-10.64.140.49"
           juju-channel: 3.4/stable
-          charmcraft-channel: latest/candidate
+          # Pinned to 3.x/stable due to https://github.com/canonical/charmcraft/issues/1845
+          charmcraft-channel: 3.x/stable
 
       - name: Run observability integration tests
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -91,4 +91,5 @@ jobs:
           charm-path: ${{ matrix.charm-path }}
           channel: ${{ steps.parse-inputs.outputs.destination_channel }}
           tag-prefix: ${{ steps.parse-inputs.outputs.tag_prefix }}
-          charmcraft-channel: latest/candidate
+          # Pinned to 3.x/stable due to https://github.com/canonical/charmcraft/issues/1845
+          charmcraft-channel: 3.x/stable


### PR DESCRIPTION
This PR is a backport that is part of closing [this issue](https://github.com/canonical/bundle-kubeflow/issues/1049).

It pins the channel used in our CI from `latest/candidate` to `3.x/stable`.

Ideally we can unpin the version when [this issue](https://github.com/canonical/charmcraft/issues/1845) is fixed.