### PR TITLE
chore(backport): Fix tag istio-pilot dashboard tag (#542)

### DIFF
--- a/charms/istio-pilot/src/grafana_dashboards/istio_control_plane.json.tmpl
+++ b/charms/istio-pilot/src/grafana_dashboards/istio_control_plane.json.tmpl
@@ -1949,7 +1949,7 @@
   "schemaVersion": 38,
   "style": "dark",
   "tags": [
-    "CKF",
+    "ckf",
     "istio"
   ],
   "templating": {


### PR DESCRIPTION
Fix the CKF tag for istio-pilot dashboard. This tag should be lowercase and not upper case.

fixes: #538