### PR TITLE
(backport) Feat: Create Terraform module

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -49,6 +49,7 @@ jobs:
         charm: [gateway, pilot]
     with:
       charm-path: ./charms/istio-${{ matrix.charm }}
+      channel: 1.22/stable
         
   integration:
     name: Integration Test

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -41,6 +41,15 @@ jobs:
       - run: sudo apt update && sudo apt install tox
       - run: tox -e ${{ matrix.charm }}-unit
 
+  terraform-checks:
+    name: Terraform
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/terraform-checks.yaml@main
+    strategy:
+      matrix:
+        charm: [gateway, pilot]
+    with:
+      charm-path: ./charms/istio-${{ matrix.charm }}
+        
   integration:
     name: Integration Test
     runs-on: ubuntu-20.04

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *__pycache__
 *.tox
 build/
+venv/
+.terraform*
+*.tfstate*

--- a/charms/istio-gateway/terraform/README.md
+++ b/charms/istio-gateway/terraform/README.md
@@ -1,0 +1,58 @@
+# Terraform module for istio-gateway
+
+This is a Terraform module facilitating the deployment of the istio-gateway charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
+
+## Requirements
+This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
+
+## API
+
+### Inputs
+The module offers the following configurable inputs:
+
+| Name | Type | Description | Required |
+| - | - | - | - |
+| `app_name`| string | Application name | False |
+| `channel`| string | Channel that the charm is deployed from | False |
+| `config`| map(string) | Map of the charm configuration options | False |
+| `model_name`| string | Name of the model that the charm is deployed on | True |
+| `resources`| map(string) | Map of the charm resources | False |
+| `revision`| number | Revision number of the charm name | False |
+
+### Outputs
+Upon applied, the module exports the following outputs:
+
+| Name | Description |
+| - | - |
+| `app_name`|  Application name |
+| `provides`| Map of `provides` endpoints |
+| `requires`|  Map of `requires` endpoints |
+
+## Usage
+
+This module is intended to be used as part of a higher-level module. When defining one, users should ensure that Terraform is aware of the `juju_model` dependency of the charm module. There are two options to do so when creating a high-level module:
+
+### Define a `juju_model` resource
+Define a `juju_model` resource and pass to the `model_name` input a reference to the `juju_model` resource's name. For example:
+
+```
+resource "juju_model" "testing" {
+  name = kubeflow
+}
+module "istio_gateway" {
+  source = "<path-to-this-directory>"
+  model_name = juju_model.testing.name
+}
+```
+
+### Define a `data` source
+Define a `data` source and pass to the `model_name` input a reference to the `data.juju_model` resource's name. This will enable Terraform to look for a `juju_model` resource with a name attribute equal to the one provided, and apply only if this is present. Otherwise, it will fail before applying anything.
+```
+data "juju_model" "testing" {
+  name = var.model_name
+}
+module "istio_gateway" {
+  source = "<path-to-this-directory>"
+  model_name = data.juju_model.testing.name
+}
+```

--- a/charms/istio-gateway/terraform/main.tf
+++ b/charms/istio-gateway/terraform/main.tf
@@ -1,0 +1,13 @@
+resource "juju_application" "istio_gateway" {
+  charm {
+    name     = "istio-gateway"
+    channel  = var.channel
+    revision = var.revision
+  }
+  config    = var.config
+  model     = var.model_name
+  name      = var.app_name
+  resources = var.resources
+  trust     = true
+  units     = 1
+}

--- a/charms/istio-gateway/terraform/outputs.tf
+++ b/charms/istio-gateway/terraform/outputs.tf
@@ -1,0 +1,15 @@
+output "app_name" {
+  value = juju_application.istio_gateway.name
+}
+
+output "provides" {
+  value = {
+    metrics_endpoint = "metrics-endpoint"
+  }
+}
+
+output "requires" {
+  value = {
+    istio_pilot = "istio-pilot"
+  }
+}

--- a/charms/istio-gateway/terraform/variables.tf
+++ b/charms/istio-gateway/terraform/variables.tf
@@ -7,7 +7,7 @@ variable "app_name" {
 variable "channel" {
   description = "Charm channel"
   type        = string
-  default     = null
+  default     = "1.22/stable"
 }
 
 variable "config" {

--- a/charms/istio-gateway/terraform/variables.tf
+++ b/charms/istio-gateway/terraform/variables.tf
@@ -1,0 +1,34 @@
+variable "app_name" {
+  description = "Application name"
+  type        = string
+  default     = "istio-gateway"
+}
+
+variable "channel" {
+  description = "Charm channel"
+  type        = string
+  default     = null
+}
+
+variable "config" {
+  description = "Map of charm configuration options"
+  type        = map(string)
+  default     = {}
+}
+
+variable "model_name" {
+  description = "Model name"
+  type        = string
+}
+
+variable "resources" {
+  description = "Map of resources"
+  type        = map(string)
+  default     = null
+}
+
+variable "revision" {
+  description = "Charm revision"
+  type        = number
+  default     = null
+}

--- a/charms/istio-gateway/terraform/versions.tf
+++ b/charms/istio-gateway/terraform/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.14.0"
+    }
+  }
+}

--- a/charms/istio-gateway/tox.ini
+++ b/charms/istio-gateway/tox.ini
@@ -64,6 +64,13 @@ deps =
     -r requirements-lint.txt
 description = Check code against coding style standards
 
+[testenv:tflint]
+allowlist_externals =
+    tflint
+commands =
+    tflint --chdir=terraform --recursive
+description = Check Terraform code against coding style standards
+
 [testenv:unit]
 commands =
     coverage run --source={[vars]src_path} \

--- a/charms/istio-pilot/terraform/README.md
+++ b/charms/istio-pilot/terraform/README.md
@@ -1,0 +1,58 @@
+# Terraform module for istio-pilot
+
+This is a Terraform module facilitating the deployment of the istio-pilot charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
+
+## Requirements
+This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
+
+## API
+
+### Inputs
+The module offers the following configurable inputs:
+
+| Name | Type | Description | Required |
+| - | - | - | - |
+| `app_name`| string | Application name | False |
+| `channel`| string | Channel that the charm is deployed from | False |
+| `config`| map(string) | Map of the charm configuration options | False |
+| `model_name`| string | Name of the model that the charm is deployed on | True |
+| `resources`| map(string) | Map of the charm resources | False |
+| `revision`| number | Revision number of the charm name | False |
+
+### Outputs
+Upon applied, the module exports the following outputs:
+
+| Name | Description |
+| - | - |
+| `app_name`|  Application name |
+| `provides`| Map of `provides` endpoints |
+| `requires`|  Map of `requires` endpoints |
+
+## Usage
+
+This module is intended to be used as part of a higher-level module. When defining one, users should ensure that Terraform is aware of the `juju_model` dependency of the charm module. There are two options to do so when creating a high-level module:
+
+### Define a `juju_model` resource
+Define a `juju_model` resource and pass to the `model_name` input a reference to the `juju_model` resource's name. For example:
+
+```
+resource "juju_model" "testing" {
+  name = kubeflow
+}
+module "istio_pilot" {
+  source = "<path-to-this-directory>"
+  model_name = juju_model.testing.name
+}
+```
+
+### Define a `data` source
+Define a `data` source and pass to the `model_name` input a reference to the `data.juju_model` resource's name. This will enable Terraform to look for a `juju_model` resource with a name attribute equal to the one provided, and apply only if this is present. Otherwise, it will fail before applying anything.
+```
+data "juju_model" "testing" {
+  name = var.model_name
+}
+module "istio_pilot" {
+  source = "<path-to-this-directory>"
+  model_name = data.juju_model.testing.name
+}
+```

--- a/charms/istio-pilot/terraform/main.tf
+++ b/charms/istio-pilot/terraform/main.tf
@@ -1,0 +1,13 @@
+resource "juju_application" "istio_pilot" {
+  charm {
+    name     = "istio-pilot"
+    channel  = var.channel
+    revision = var.revision
+  }
+  config    = var.config
+  model     = var.model_name
+  name      = var.app_name
+  resources = var.resources
+  trust     = true
+  units     = 1
+}

--- a/charms/istio-pilot/terraform/outputs.tf
+++ b/charms/istio-pilot/terraform/outputs.tf
@@ -1,0 +1,20 @@
+output "app_name" {
+  value = juju_application.istio_pilot.name
+}
+
+output "provides" {
+  value = {
+    metrics_endpoint  = "metrics-endpoint",
+    grafana_dashboard = "grafana-dashboard",
+    istio_pilot       = "istio-pilot",
+    ingress           = "ingress",
+    ingress_auth      = "ingress-auth",
+    gateway_info      = "gatway-info"
+  }
+}
+
+output "requires" {
+  value = {
+    certificates = "certificates"
+  }
+}

--- a/charms/istio-pilot/terraform/variables.tf
+++ b/charms/istio-pilot/terraform/variables.tf
@@ -1,0 +1,34 @@
+variable "app_name" {
+  description = "Application name"
+  type        = string
+  default     = "istio-pilot"
+}
+
+variable "channel" {
+  description = "Charm channel"
+  type        = string
+  default     = null
+}
+
+variable "config" {
+  description = "Map of charm configuration options"
+  type        = map(string)
+  default     = {}
+}
+
+variable "model_name" {
+  description = "Model name"
+  type        = string
+}
+
+variable "resources" {
+  description = "Map of resources"
+  type        = map(string)
+  default     = null
+}
+
+variable "revision" {
+  description = "Charm revision"
+  type        = number
+  default     = null
+}

--- a/charms/istio-pilot/terraform/variables.tf
+++ b/charms/istio-pilot/terraform/variables.tf
@@ -7,7 +7,7 @@ variable "app_name" {
 variable "channel" {
   description = "Charm channel"
   type        = string
-  default     = null
+  default     = "1.22/stable"
 }
 
 variable "config" {

--- a/charms/istio-pilot/terraform/versions.tf
+++ b/charms/istio-pilot/terraform/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.14.0"
+    }
+  }
+}

--- a/charms/istio-pilot/tox.ini
+++ b/charms/istio-pilot/tox.ini
@@ -65,6 +65,13 @@ deps =
     -r requirements-lint.txt
 description = Check code against coding style standards
 
+[testenv:tflint]
+allowlist_externals =
+    tflint
+commands =
+    tflint --chdir=terraform --recursive
+description = Check Terraform code against coding style standards
+
 [testenv:unit]
 commands =
     coverage run --source={[vars]src_path} \


### PR DESCRIPTION
Ref: #552 and #530.

This PR is a backport that creates a `terraform/` directory in each charm that hosts the Terraform module. It follows the structure proposed in [this spec](https://docs.google.com/document/d/1EG71A2pJ244PQRaGVzGj7Mx2B_bzE4U_OSqx4eeVI1E/edit).

To test the module:
- Clone the repository and switch to this branch.
- First run `tox -e tflint` to ensure that linting is correct
- Change to the `terraform/` directory and run `terraform init`.
- Run `terraform apply -var "channel=1.22/stable" -var "model_name=kubeflow" --auto-approve` and wait until the charm is `Active` and `Idle`.