### PR TITLE
chore: update python dependencies + pin pip

### DIFF
--- a/charms/istio-gateway/requirements-fmt.txt
+++ b/charms/istio-gateway/requirements-fmt.txt
@@ -4,21 +4,21 @@
 #
 #    pip-compile requirements-fmt.in
 #
-black==23.7.0
+black==24.8.0
     # via -r requirements-fmt.in
 click==8.1.7
     # via black
-isort==5.12.0
+isort==5.13.2
     # via -r requirements-fmt.in
 mypy-extensions==1.0.0
     # via black
-packaging==23.1
+packaging==24.2
     # via black
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
-platformdirs==3.10.0
+platformdirs==4.3.6
     # via black
-tomli==2.0.1
+tomli==2.2.1
     # via black
-typing-extensions==4.7.1
+typing-extensions==4.12.2
     # via black

--- a/charms/istio-gateway/requirements-lint.txt
+++ b/charms/istio-gateway/requirements-lint.txt
@@ -4,47 +4,47 @@
 #
 #    pip-compile requirements-lint.in
 #
-black==23.7.0
+black==24.8.0
     # via -r requirements-lint.in
 click==8.1.7
     # via black
-codespell==2.2.5
+codespell==2.3.0
     # via -r requirements-lint.in
-flake8==6.0.0
+flake8==7.0.0
     # via
     #   -r requirements-lint.in
     #   flake8-builtins
     #   pep8-naming
     #   pyproject-flake8
-flake8-builtins==2.1.0
+flake8-builtins==2.5.0
     # via -r requirements-lint.in
 flake8-copyright==0.2.4
     # via -r requirements-lint.in
-isort==5.12.0
+isort==5.13.2
     # via -r requirements-lint.in
 mccabe==0.7.0
     # via flake8
 mypy-extensions==1.0.0
     # via black
-packaging==23.1
+packaging==24.2
     # via black
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
-pep8-naming==0.13.3
+pep8-naming==0.14.1
     # via -r requirements-lint.in
-platformdirs==3.10.0
+platformdirs==4.3.6
     # via black
-pycodestyle==2.10.0
+pycodestyle==2.11.1
     # via flake8
-pyflakes==3.0.1
+pyflakes==3.2.0
     # via flake8
-pyproject-flake8==6.0.0.post1
+pyproject-flake8==7.0.0
     # via -r requirements-lint.in
-tomli==2.0.1
+tomli==2.2.1
     # via
     #   black
     #   pyproject-flake8
-typing-extensions==4.7.1
+typing-extensions==4.12.2
     # via black
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/charms/istio-gateway/requirements-unit.txt
+++ b/charms/istio-gateway/requirements-unit.txt
@@ -6,20 +6,20 @@
 #
 annotated-types==0.7.0
     # via pydantic
-anyio==4.4.0
+anyio==4.5.2
     # via httpx
-attrs==23.2.0
+attrs==24.2.0
     # via jsonschema
-certifi==2024.7.4
+certifi==2024.8.30
     # via
     #   httpcore
     #   httpx
     #   requests
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via requests
-cosl==0.0.14
+cosl==0.0.45
     # via -r requirements.in
-coverage==7.6.0
+coverage==7.6.1
     # via -r requirements-unit.in
 exceptiongroup==1.2.2
     # via
@@ -27,16 +27,16 @@ exceptiongroup==1.2.2
     #   pytest
 h11==0.14.0
     # via httpcore
-httpcore==1.0.5
+httpcore==1.0.7
     # via httpx
-httpx==0.27.0
+httpx==0.27.2
     # via lightkube
-idna==3.7
+idna==3.10
     # via
     #   anyio
     #   httpx
     #   requests
-importlib-resources==6.4.0
+importlib-resources==6.4.5
     # via jsonschema
 iniconfig==2.0.0
     # via pytest
@@ -44,10 +44,11 @@ jinja2==3.1.4
     # via -r requirements.in
 jsonschema==4.17.3
     # via serialized-data-interface
-lightkube==0.15.3
+lightkube==0.15.6
     # via
     #   -r requirements-unit.in
     #   -r requirements.in
+    #   cosl
 lightkube-models==1.27.1.8
     # via
     #   -r requirements.in
@@ -56,31 +57,31 @@ markupsafe==2.1.5
     # via jinja2
 oci-image==1.0.0
     # via -r requirements.in
-ops==2.15.0
+ops==2.17.1
     # via
     #   -r requirements-unit.in
     #   -r requirements.in
     #   cosl
     #   serialized-data-interface
-packaging==24.1
+packaging==24.2
     # via pytest
 pkgutil-resolve-name==1.3.10
     # via jsonschema
 pluggy==1.5.0
     # via pytest
-pydantic==2.8.2
+pydantic==2.10.3
     # via cosl
-pydantic-core==2.20.1
+pydantic-core==2.27.1
     # via pydantic
 pyrsistent==0.20.0
     # via jsonschema
-pytest==8.3.1
+pytest==8.3.4
     # via
     #   -r requirements-unit.in
     #   pytest-mock
 pytest-mock==3.14.0
     # via -r requirements-unit.in
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   -r requirements-unit.in
     #   cosl
@@ -97,7 +98,9 @@ sniffio==1.3.1
     # via
     #   anyio
     #   httpx
-tomli==2.0.1
+tenacity==9.0.0
+    # via cosl
+tomli==2.2.1
     # via pytest
 typing-extensions==4.12.2
     # via
@@ -106,9 +109,9 @@ typing-extensions==4.12.2
     #   cosl
     #   pydantic
     #   pydantic-core
-urllib3==2.2.2
+urllib3==2.2.3
     # via requests
 websocket-client==1.8.0
     # via ops
-zipp==3.19.2
+zipp==3.20.2
     # via importlib-resources

--- a/charms/istio-gateway/requirements-unit.txt
+++ b/charms/istio-gateway/requirements-unit.txt
@@ -8,16 +8,16 @@ annotated-types==0.7.0
     # via pydantic
 anyio==4.5.2
     # via httpx
-attrs==24.2.0
+attrs==24.3.0
     # via jsonschema
-certifi==2024.8.30
+certifi==2024.12.14
     # via
     #   httpcore
     #   httpx
     #   requests
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via requests
-cosl==0.0.45
+cosl==0.0.50
     # via -r requirements.in
 coverage==7.6.1
     # via -r requirements-unit.in
@@ -29,7 +29,7 @@ h11==0.14.0
     # via httpcore
 httpcore==1.0.7
     # via httpx
-httpx==0.27.2
+httpx==0.28.1
     # via lightkube
 idna==3.10
     # via
@@ -40,16 +40,16 @@ importlib-resources==6.4.5
     # via jsonschema
 iniconfig==2.0.0
     # via pytest
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements.in
 jsonschema==4.17.3
     # via serialized-data-interface
-lightkube==0.15.6
+lightkube==0.17.1
     # via
     #   -r requirements-unit.in
     #   -r requirements.in
     #   cosl
-lightkube-models==1.27.1.8
+lightkube-models==1.32.0.8
     # via
     #   -r requirements.in
     #   lightkube
@@ -69,9 +69,9 @@ pkgutil-resolve-name==1.3.10
     # via jsonschema
 pluggy==1.5.0
     # via pytest
-pydantic==2.10.3
+pydantic==2.10.5
     # via cosl
-pydantic-core==2.27.1
+pydantic-core==2.27.2
     # via pydantic
 pyrsistent==0.20.0
     # via jsonschema
@@ -95,9 +95,7 @@ requests==2.32.3
 serialized-data-interface==0.7.0
     # via -r requirements.in
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 tenacity==9.0.0
     # via cosl
 tomli==2.2.1

--- a/charms/istio-gateway/requirements.in
+++ b/charms/istio-gateway/requirements.in
@@ -3,7 +3,6 @@ ops
 requests
 serialized-data-interface
 lightkube
-lightkube-models<1.28
-# We're trying to use a deprecated API and it needs to be fixed before KF 1.7 (because 1.7 must support k8s 1.25)
+lightkube-models
 oci-image
 cosl

--- a/charms/istio-gateway/requirements.txt
+++ b/charms/istio-gateway/requirements.txt
@@ -6,40 +6,42 @@
 #
 annotated-types==0.7.0
     # via pydantic
-anyio==4.4.0
+anyio==4.5.2
     # via httpx
-attrs==23.2.0
+attrs==24.2.0
     # via jsonschema
-certifi==2024.7.4
+certifi==2024.8.30
     # via
     #   httpcore
     #   httpx
     #   requests
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via requests
-cosl==0.0.15
+cosl==0.0.45
     # via -r requirements.in
 exceptiongroup==1.2.2
     # via anyio
 h11==0.14.0
     # via httpcore
-httpcore==1.0.5
+httpcore==1.0.7
     # via httpx
-httpx==0.27.0
+httpx==0.27.2
     # via lightkube
-idna==3.7
+idna==3.10
     # via
     #   anyio
     #   httpx
     #   requests
-importlib-resources==6.4.0
+importlib-resources==6.4.5
     # via jsonschema
 jinja2==3.1.4
     # via -r requirements.in
 jsonschema==4.17.3
     # via serialized-data-interface
-lightkube==0.15.3
-    # via -r requirements.in
+lightkube==0.15.6
+    # via
+    #   -r requirements.in
+    #   cosl
 lightkube-models==1.27.1.8
     # via
     #   -r requirements.in
@@ -48,20 +50,20 @@ markupsafe==2.1.5
     # via jinja2
 oci-image==1.0.0
     # via -r requirements.in
-ops==2.15.0
+ops==2.17.1
     # via
     #   -r requirements.in
     #   cosl
     #   serialized-data-interface
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-pydantic==2.8.2
+pydantic==2.10.3
     # via cosl
-pydantic-core==2.20.1
+pydantic-core==2.27.1
     # via pydantic
 pyrsistent==0.20.0
     # via jsonschema
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   cosl
     #   lightkube
@@ -77,6 +79,8 @@ sniffio==1.3.1
     # via
     #   anyio
     #   httpx
+tenacity==9.0.0
+    # via cosl
 typing-extensions==4.12.2
     # via
     #   annotated-types
@@ -84,9 +88,9 @@ typing-extensions==4.12.2
     #   cosl
     #   pydantic
     #   pydantic-core
-urllib3==2.2.2
+urllib3==2.2.3
     # via requests
 websocket-client==1.8.0
     # via ops
-zipp==3.19.2
+zipp==3.20.2
     # via importlib-resources

--- a/charms/istio-gateway/requirements.txt
+++ b/charms/istio-gateway/requirements.txt
@@ -8,16 +8,16 @@ annotated-types==0.7.0
     # via pydantic
 anyio==4.5.2
     # via httpx
-attrs==24.2.0
+attrs==24.3.0
     # via jsonschema
-certifi==2024.8.30
+certifi==2024.12.14
     # via
     #   httpcore
     #   httpx
     #   requests
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via requests
-cosl==0.0.45
+cosl==0.0.50
     # via -r requirements.in
 exceptiongroup==1.2.2
     # via anyio
@@ -25,7 +25,7 @@ h11==0.14.0
     # via httpcore
 httpcore==1.0.7
     # via httpx
-httpx==0.27.2
+httpx==0.28.1
     # via lightkube
 idna==3.10
     # via
@@ -34,15 +34,15 @@ idna==3.10
     #   requests
 importlib-resources==6.4.5
     # via jsonschema
-jinja2==3.1.4
+jinja2==3.1.5
     # via -r requirements.in
 jsonschema==4.17.3
     # via serialized-data-interface
-lightkube==0.15.6
+lightkube==0.17.1
     # via
     #   -r requirements.in
     #   cosl
-lightkube-models==1.27.1.8
+lightkube-models==1.32.0.8
     # via
     #   -r requirements.in
     #   lightkube
@@ -57,9 +57,9 @@ ops==2.17.1
     #   serialized-data-interface
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-pydantic==2.10.3
+pydantic==2.10.5
     # via cosl
-pydantic-core==2.27.1
+pydantic-core==2.27.2
     # via pydantic
 pyrsistent==0.20.0
     # via jsonschema
@@ -76,9 +76,7 @@ requests==2.32.3
 serialized-data-interface==0.7.0
     # via -r requirements.in
 sniffio==1.3.1
-    # via
-    #   anyio
-    #   httpx
+    # via anyio
 tenacity==9.0.0
     # via cosl
 typing-extensions==4.12.2

--- a/charms/istio-gateway/tox.ini
+++ b/charms/istio-gateway/tox.ini
@@ -38,6 +38,8 @@ commands =
     bash -c 'for pattern in "requirements.in" "requirements-fmt.in" "requirements*.in"; do find . -type f -name "$pattern" -exec bash -c "cd \$(dirname "{}") && pip-compile --resolver=backtracking \$(basename "{}")" \;; done'
 deps =
     pip-tools
+    # Pin due to https://github.com/jazzband/pip-tools/issues/2131
+    pip==24.2
 description = Update requirements files by executing pip-compile on all requirements*.in files, including those in subdirs.
 
 [testenv:fmt]

--- a/charms/istio-pilot/requirements-fmt.txt
+++ b/charms/istio-pilot/requirements-fmt.txt
@@ -4,21 +4,21 @@
 #
 #    pip-compile requirements-fmt.in
 #
-black==23.7.0
+black==24.8.0
     # via -r requirements-fmt.in
 click==8.1.7
     # via black
-isort==5.12.0
+isort==5.13.2
     # via -r requirements-fmt.in
 mypy-extensions==1.0.0
     # via black
-packaging==23.1
+packaging==24.2
     # via black
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
-platformdirs==3.10.0
+platformdirs==4.3.6
     # via black
-tomli==2.0.1
+tomli==2.2.1
     # via black
-typing-extensions==4.7.1
+typing-extensions==4.12.2
     # via black

--- a/charms/istio-pilot/requirements-lint.txt
+++ b/charms/istio-pilot/requirements-lint.txt
@@ -4,47 +4,47 @@
 #
 #    pip-compile requirements-lint.in
 #
-black==23.7.0
+black==24.8.0
     # via -r requirements-lint.in
 click==8.1.7
     # via black
-codespell==2.2.5
+codespell==2.3.0
     # via -r requirements-lint.in
-flake8==6.0.0
+flake8==7.0.0
     # via
     #   -r requirements-lint.in
     #   flake8-builtins
     #   pep8-naming
     #   pyproject-flake8
-flake8-builtins==2.1.0
+flake8-builtins==2.5.0
     # via -r requirements-lint.in
 flake8-copyright==0.2.4
     # via -r requirements-lint.in
-isort==5.12.0
+isort==5.13.2
     # via -r requirements-lint.in
 mccabe==0.7.0
     # via flake8
 mypy-extensions==1.0.0
     # via black
-packaging==23.1
+packaging==24.2
     # via black
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
-pep8-naming==0.13.3
+pep8-naming==0.14.1
     # via -r requirements-lint.in
-platformdirs==3.10.0
+platformdirs==4.3.6
     # via black
-pycodestyle==2.10.0
+pycodestyle==2.11.1
     # via flake8
-pyflakes==3.0.1
+pyflakes==3.2.0
     # via flake8
-pyproject-flake8==6.0.0.post1
+pyproject-flake8==7.0.0
     # via -r requirements-lint.in
-tomli==2.0.1
+tomli==2.2.1
     # via
     #   black
     #   pyproject-flake8
-typing-extensions==4.7.1
+typing-extensions==4.12.2
     # via black
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/charms/istio-pilot/requirements-unit.txt
+++ b/charms/istio-pilot/requirements-unit.txt
@@ -6,36 +6,38 @@
 #
 annotated-types==0.7.0
     # via pydantic
-anyio==4.4.0
+anyio==4.5.2
     # via httpx
-attrs==23.2.0
+attrs==24.2.0
     # via jsonschema
-bcrypt==4.2.0
+backports-strenum==1.3.1
+    # via juju
+bcrypt==4.2.1
     # via paramiko
-cachetools==5.4.0
+cachetools==5.5.0
     # via google-auth
-certifi==2024.7.4
+certifi==2024.8.30
     # via
     #   httpcore
     #   httpx
     #   kubernetes
     #   requests
-cffi==1.16.0
+cffi==1.17.1
     # via
     #   -r requirements.in
     #   cryptography
     #   pynacl
-charmed-kubeflow-chisme==0.4.2
+charmed-kubeflow-chisme==0.4.3
     # via
     #   -r requirements-unit.in
     #   -r requirements.in
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via requests
-cosl==0.0.15
+cosl==0.0.45
     # via -r requirements.in
-coverage==7.6.0
+coverage==7.6.1
     # via -r requirements-unit.in
-cryptography==43.0.0
+cryptography==44.0.0
     # via
     #   -r requirements-unit.in
     #   -r requirements.in
@@ -46,22 +48,22 @@ exceptiongroup==1.2.2
     # via
     #   anyio
     #   pytest
-google-auth==2.32.0
+google-auth==2.36.0
     # via kubernetes
 h11==0.14.0
     # via httpcore
-httpcore==1.0.5
+httpcore==1.0.7
     # via httpx
-httpx==0.27.0
+httpx==0.27.2
     # via lightkube
 hvac==2.3.0
     # via juju
-idna==3.7
+idna==3.10
     # via
     #   anyio
     #   httpx
     #   requests
-importlib-resources==6.4.0
+importlib-resources==6.4.5
     # via jsonschema
 iniconfig==2.0.0
     # via pytest
@@ -75,15 +77,16 @@ jsonschema==4.17.3
     #   -r requirements-unit.in
     #   -r requirements.in
     #   serialized-data-interface
-juju==3.5.2.0
+juju==3.6.0.0
     # via charmed-kubeflow-chisme
 kubernetes==30.1.0
     # via juju
-lightkube==0.15.3
+lightkube==0.15.6
     # via
     #   -r requirements-unit.in
     #   -r requirements.in
     #   charmed-kubeflow-chisme
+    #   cosl
 lightkube-models==1.26.0.8
     # via
     #   -r requirements.in
@@ -98,7 +101,7 @@ oauthlib==3.2.2
     # via
     #   kubernetes
     #   requests-oauthlib
-ops==2.15.0
+ops==2.17.1
     # via
     #   -r requirements-unit.in
     #   -r requirements.in
@@ -107,31 +110,31 @@ ops==2.15.0
     #   serialized-data-interface
 ordered-set==4.1.0
     # via deepdiff
-packaging==24.1
+packaging==24.2
     # via
     #   -r requirements.in
     #   juju
     #   pytest
-paramiko==3.4.0
+paramiko==3.5.0
     # via juju
 pkgutil-resolve-name==1.3.10
     # via jsonschema
 pluggy==1.5.0
     # via pytest
-protobuf==5.27.2
+protobuf==5.29.1
     # via macaroonbakery
-pyasn1==0.6.0
+pyasn1==0.6.1
     # via
     #   juju
     #   pyasn1-modules
     #   rsa
-pyasn1-modules==0.4.0
+pyasn1-modules==0.4.1
     # via google-auth
 pycparser==2.22
     # via cffi
-pydantic==2.8.2
+pydantic==2.10.3
     # via cosl
-pydantic-core==2.20.1
+pydantic-core==2.27.1
     # via pydantic
 pymacaroons==0.13.0
     # via macaroonbakery
@@ -146,7 +149,7 @@ pyrfc3339==1.1
     #   macaroonbakery
 pyrsistent==0.20.0
     # via jsonschema
-pytest==8.3.1
+pytest==8.3.4
     # via
     #   -r requirements-unit.in
     #   pytest-mock
@@ -154,9 +157,9 @@ pytest-mock==3.14.0
     # via -r requirements-unit.in
 python-dateutil==2.9.0.post0
     # via kubernetes
-pytz==2024.1
+pytz==2024.2
     # via pyrfc3339
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   -r requirements-unit.in
     #   cosl
@@ -185,7 +188,7 @@ serialized-data-interface==0.7.0
     # via
     #   -r requirements.in
     #   charmed-kubeflow-chisme
-six==1.16.0
+six==1.17.0
     # via
     #   kubernetes
     #   macaroonbakery
@@ -195,12 +198,13 @@ sniffio==1.3.1
     # via
     #   anyio
     #   httpx
-tenacity==8.5.0
+tenacity==9.0.0
     # via
     #   -r requirements-unit.in
     #   -r requirements.in
     #   charmed-kubeflow-chisme
-tomli==2.0.1
+    #   cosl
+tomli==2.2.1
     # via pytest
 toposort==1.10
     # via juju
@@ -209,12 +213,13 @@ typing-extensions==4.12.2
     #   annotated-types
     #   anyio
     #   cosl
+    #   juju
     #   pydantic
     #   pydantic-core
     #   typing-inspect
 typing-inspect==0.9.0
     # via juju
-urllib3==2.2.2
+urllib3==2.2.3
     # via
     #   kubernetes
     #   requests
@@ -222,7 +227,7 @@ websocket-client==1.8.0
     # via
     #   kubernetes
     #   ops
-websockets==12.0
+websockets==13.1
     # via juju
-zipp==3.19.2
+zipp==3.20.2
     # via importlib-resources

--- a/charms/istio-pilot/requirements-unit.txt
+++ b/charms/istio-pilot/requirements-unit.txt
@@ -8,7 +8,7 @@ annotated-types==0.7.0
     # via pydantic
 anyio==4.5.2
     # via httpx
-attrs==24.2.0
+attrs==24.3.0
     # via jsonschema
 backports-strenum==1.3.1
     # via juju
@@ -16,7 +16,7 @@ bcrypt==4.2.1
     # via paramiko
 cachetools==5.5.0
     # via google-auth
-certifi==2024.8.30
+certifi==2024.12.14
     # via
     #   httpcore
     #   httpx
@@ -27,13 +27,13 @@ cffi==1.17.1
     #   -r requirements.in
     #   cryptography
     #   pynacl
-charmed-kubeflow-chisme==0.4.3
+charmed-kubeflow-chisme==0.4.6
     # via
     #   -r requirements-unit.in
     #   -r requirements.in
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via requests
-cosl==0.0.45
+cosl==0.0.50
     # via -r requirements.in
 coverage==7.6.1
     # via -r requirements-unit.in
@@ -48,14 +48,16 @@ exceptiongroup==1.2.2
     # via
     #   anyio
     #   pytest
-google-auth==2.36.0
+google-auth==2.37.0
     # via kubernetes
 h11==0.14.0
     # via httpcore
 httpcore==1.0.7
     # via httpx
 httpx==0.27.2
-    # via lightkube
+    # via
+    #   charmed-kubeflow-chisme
+    #   lightkube
 hvac==2.3.0
     # via juju
 idna==3.10
@@ -67,7 +69,7 @@ importlib-resources==6.4.5
     # via jsonschema
 iniconfig==2.0.0
     # via pytest
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -r requirements-unit.in
     #   -r requirements.in
@@ -77,17 +79,17 @@ jsonschema==4.17.3
     #   -r requirements-unit.in
     #   -r requirements.in
     #   serialized-data-interface
-juju==3.6.0.0
+juju==3.6.1.0
     # via charmed-kubeflow-chisme
 kubernetes==30.1.0
     # via juju
-lightkube==0.15.6
+lightkube==0.17.1
     # via
     #   -r requirements-unit.in
     #   -r requirements.in
     #   charmed-kubeflow-chisme
     #   cosl
-lightkube-models==1.26.0.8
+lightkube-models==1.32.0.8
     # via
     #   -r requirements.in
     #   lightkube
@@ -121,7 +123,7 @@ pkgutil-resolve-name==1.3.10
     # via jsonschema
 pluggy==1.5.0
     # via pytest
-protobuf==5.29.1
+protobuf==5.29.3
     # via macaroonbakery
 pyasn1==0.6.1
     # via
@@ -132,9 +134,9 @@ pyasn1-modules==0.4.1
     # via google-auth
 pycparser==2.22
     # via cffi
-pydantic==2.10.3
+pydantic==2.10.5
     # via cosl
-pydantic-core==2.27.1
+pydantic-core==2.27.2
     # via pydantic
 pymacaroons==0.13.0
     # via macaroonbakery
@@ -180,7 +182,7 @@ requests-oauthlib==2.0.0
     # via kubernetes
 rsa==4.9
     # via google-auth
-ruamel-yaml==0.18.6
+ruamel-yaml==0.18.10
     # via charmed-kubeflow-chisme
 ruamel-yaml-clib==0.2.8
     # via ruamel-yaml

--- a/charms/istio-pilot/requirements.in
+++ b/charms/istio-pilot/requirements.in
@@ -1,10 +1,7 @@
 charmed-kubeflow-chisme
 jinja2
 lightkube
-# Pinning lightkube-models to keep compatibility with istio 1.17
-# which supports versions 1.23, 1.24, 1.25, 1.26 of k8s
-# Update the pin when this charm is upgraded to <=1.18
-lightkube-models<1.27
+lightkube-models
 ops
 packaging
 requests

--- a/charms/istio-pilot/requirements.txt
+++ b/charms/istio-pilot/requirements.txt
@@ -8,7 +8,7 @@ annotated-types==0.7.0
     # via pydantic
 anyio==4.5.2
     # via httpx
-attrs==24.2.0
+attrs==24.3.0
     # via jsonschema
 backports-strenum==1.3.1
     # via juju
@@ -16,7 +16,7 @@ bcrypt==4.2.1
     # via paramiko
 cachetools==5.5.0
     # via google-auth
-certifi==2024.8.30
+certifi==2024.12.14
     # via
     #   httpcore
     #   httpx
@@ -27,11 +27,11 @@ cffi==1.17.1
     #   -r requirements.in
     #   cryptography
     #   pynacl
-charmed-kubeflow-chisme==0.4.3
+charmed-kubeflow-chisme==0.4.6
     # via -r requirements.in
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via requests
-cosl==0.0.45
+cosl==0.0.50
     # via -r requirements.in
 cryptography==44.0.0
     # via
@@ -41,14 +41,16 @@ deepdiff==6.2.1
     # via charmed-kubeflow-chisme
 exceptiongroup==1.2.2
     # via anyio
-google-auth==2.36.0
+google-auth==2.37.0
     # via kubernetes
 h11==0.14.0
     # via httpcore
 httpcore==1.0.7
     # via httpx
 httpx==0.27.2
-    # via lightkube
+    # via
+    #   charmed-kubeflow-chisme
+    #   lightkube
 hvac==2.3.0
     # via juju
 idna==3.10
@@ -58,7 +60,7 @@ idna==3.10
     #   requests
 importlib-resources==6.4.5
     # via jsonschema
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -r requirements.in
     #   charmed-kubeflow-chisme
@@ -66,16 +68,16 @@ jsonschema==4.17.3
     # via
     #   -r requirements.in
     #   serialized-data-interface
-juju==3.6.0.0
+juju==3.6.1.0
     # via charmed-kubeflow-chisme
 kubernetes==30.1.0
     # via juju
-lightkube==0.15.6
+lightkube==0.17.1
     # via
     #   -r requirements.in
     #   charmed-kubeflow-chisme
     #   cosl
-lightkube-models==1.26.0.8
+lightkube-models==1.32.0.8
     # via
     #   -r requirements.in
     #   lightkube
@@ -105,7 +107,7 @@ paramiko==3.5.0
     # via juju
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-protobuf==5.29.1
+protobuf==5.29.3
     # via macaroonbakery
 pyasn1==0.6.1
     # via
@@ -116,9 +118,9 @@ pyasn1-modules==0.4.1
     # via google-auth
 pycparser==2.22
     # via cffi
-pydantic==2.10.3
+pydantic==2.10.5
     # via cosl
-pydantic-core==2.27.1
+pydantic-core==2.27.2
     # via pydantic
 pymacaroons==0.13.0
     # via macaroonbakery
@@ -157,7 +159,7 @@ requests-oauthlib==2.0.0
     # via kubernetes
 rsa==4.9
     # via google-auth
-ruamel-yaml==0.18.6
+ruamel-yaml==0.18.10
     # via charmed-kubeflow-chisme
 ruamel-yaml-clib==0.2.8
     # via ruamel-yaml

--- a/charms/istio-pilot/requirements.txt
+++ b/charms/istio-pilot/requirements.txt
@@ -6,32 +6,34 @@
 #
 annotated-types==0.7.0
     # via pydantic
-anyio==4.4.0
+anyio==4.5.2
     # via httpx
-attrs==23.2.0
+attrs==24.2.0
     # via jsonschema
-bcrypt==4.2.0
+backports-strenum==1.3.1
+    # via juju
+bcrypt==4.2.1
     # via paramiko
-cachetools==5.4.0
+cachetools==5.5.0
     # via google-auth
-certifi==2024.7.4
+certifi==2024.8.30
     # via
     #   httpcore
     #   httpx
     #   kubernetes
     #   requests
-cffi==1.16.0
+cffi==1.17.1
     # via
     #   -r requirements.in
     #   cryptography
     #   pynacl
-charmed-kubeflow-chisme==0.4.2
+charmed-kubeflow-chisme==0.4.3
     # via -r requirements.in
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via requests
-cosl==0.0.15
+cosl==0.0.45
     # via -r requirements.in
-cryptography==43.0.0
+cryptography==44.0.0
     # via
     #   -r requirements.in
     #   paramiko
@@ -39,22 +41,22 @@ deepdiff==6.2.1
     # via charmed-kubeflow-chisme
 exceptiongroup==1.2.2
     # via anyio
-google-auth==2.32.0
+google-auth==2.36.0
     # via kubernetes
 h11==0.14.0
     # via httpcore
-httpcore==1.0.5
+httpcore==1.0.7
     # via httpx
-httpx==0.27.0
+httpx==0.27.2
     # via lightkube
 hvac==2.3.0
     # via juju
-idna==3.7
+idna==3.10
     # via
     #   anyio
     #   httpx
     #   requests
-importlib-resources==6.4.0
+importlib-resources==6.4.5
     # via jsonschema
 jinja2==3.1.4
     # via
@@ -64,14 +66,15 @@ jsonschema==4.17.3
     # via
     #   -r requirements.in
     #   serialized-data-interface
-juju==3.5.2.0
+juju==3.6.0.0
     # via charmed-kubeflow-chisme
 kubernetes==30.1.0
     # via juju
-lightkube==0.15.3
+lightkube==0.15.6
     # via
     #   -r requirements.in
     #   charmed-kubeflow-chisme
+    #   cosl
 lightkube-models==1.26.0.8
     # via
     #   -r requirements.in
@@ -86,7 +89,7 @@ oauthlib==3.2.2
     # via
     #   kubernetes
     #   requests-oauthlib
-ops==2.15.0
+ops==2.17.1
     # via
     #   -r requirements.in
     #   charmed-kubeflow-chisme
@@ -94,28 +97,28 @@ ops==2.15.0
     #   serialized-data-interface
 ordered-set==4.1.0
     # via deepdiff
-packaging==24.1
+packaging==24.2
     # via
     #   -r requirements.in
     #   juju
-paramiko==3.4.0
+paramiko==3.5.0
     # via juju
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-protobuf==5.27.2
+protobuf==5.29.1
     # via macaroonbakery
-pyasn1==0.6.0
+pyasn1==0.6.1
     # via
     #   juju
     #   pyasn1-modules
     #   rsa
-pyasn1-modules==0.4.0
+pyasn1-modules==0.4.1
     # via google-auth
 pycparser==2.22
     # via cffi
-pydantic==2.8.2
+pydantic==2.10.3
     # via cosl
-pydantic-core==2.20.1
+pydantic-core==2.27.1
     # via pydantic
 pymacaroons==0.13.0
     # via macaroonbakery
@@ -132,9 +135,9 @@ pyrsistent==0.20.0
     # via jsonschema
 python-dateutil==2.9.0.post0
     # via kubernetes
-pytz==2024.1
+pytz==2024.2
     # via pyrfc3339
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   cosl
     #   juju
@@ -162,7 +165,7 @@ serialized-data-interface==0.7.0
     # via
     #   -r requirements.in
     #   charmed-kubeflow-chisme
-six==1.16.0
+six==1.17.0
     # via
     #   kubernetes
     #   macaroonbakery
@@ -172,10 +175,11 @@ sniffio==1.3.1
     # via
     #   anyio
     #   httpx
-tenacity==8.5.0
+tenacity==9.0.0
     # via
     #   -r requirements.in
     #   charmed-kubeflow-chisme
+    #   cosl
 toposort==1.10
     # via juju
 typing-extensions==4.12.2
@@ -183,12 +187,13 @@ typing-extensions==4.12.2
     #   annotated-types
     #   anyio
     #   cosl
+    #   juju
     #   pydantic
     #   pydantic-core
     #   typing-inspect
 typing-inspect==0.9.0
     # via juju
-urllib3==2.2.2
+urllib3==2.2.3
     # via
     #   kubernetes
     #   requests
@@ -196,7 +201,7 @@ websocket-client==1.8.0
     # via
     #   kubernetes
     #   ops
-websockets==12.0
+websockets==13.1
     # via juju
-zipp==3.19.2
+zipp==3.20.2
     # via importlib-resources

--- a/charms/istio-pilot/tox.ini
+++ b/charms/istio-pilot/tox.ini
@@ -39,6 +39,8 @@ commands =
     bash -c 'for pattern in "requirements.in" "requirements-fmt.in" "requirements*.in"; do find . -type f -name "$pattern" -exec bash -c "cd \$(dirname "{}") && pip-compile --resolver=backtracking \$(basename "{}")" \;; done'
 deps =
     pip-tools
+    # Pin due to https://github.com/jazzband/pip-tools/issues/2131
+    pip==24.2
 description = Update requirements files by executing pip-compile on all requirements*.in files, including those in subdirs.
 
 [testenv:fmt]

--- a/requirements-fmt.txt
+++ b/requirements-fmt.txt
@@ -4,21 +4,21 @@
 #
 #    pip-compile requirements-fmt.in
 #
-black==23.7.0
+black==24.8.0
     # via -r requirements-fmt.in
 click==8.1.7
     # via black
-isort==5.12.0
+isort==5.13.2
     # via -r requirements-fmt.in
 mypy-extensions==1.0.0
     # via black
-packaging==23.1
+packaging==24.2
     # via black
-pathspec==0.11.2
+pathspec==0.12.1
     # via black
-platformdirs==3.10.0
+platformdirs==4.3.6
     # via black
-tomli==2.0.1
+tomli==2.2.1
     # via black
-typing-extensions==4.7.1
+typing-extensions==4.12.2
     # via black

--- a/requirements-integration.txt
+++ b/requirements-integration.txt
@@ -4,45 +4,49 @@
 #
 #    pip-compile requirements-integration.in
 #
-aiohttp==3.9.5
+aiohappyeyeballs==2.4.4
+    # via aiohttp
+aiohttp==3.10.11
     # via -r requirements-integration.in
 aiosignal==1.3.1
     # via aiohttp
-anyio==4.0.0
-    # via httpcore
-asttokens==2.4.0
+anyio==4.5.2
+    # via httpx
+asttokens==3.0.0
     # via stack-data
-async-timeout==4.0.3
+async-timeout==5.0.1
     # via aiohttp
 asyncio==3.4.3
     # via -r requirements-integration.in
-attrs==23.1.0
+attrs==24.2.0
     # via
     #   aiohttp
     #   jsonschema
 backcall==0.2.0
     # via ipython
-bcrypt==4.0.1
+backports-strenum==1.3.1
+    # via juju
+bcrypt==4.2.1
     # via paramiko
-beautifulsoup4==4.12.2
+beautifulsoup4==4.12.3
     # via -r requirements-integration.in
-cachetools==5.3.1
+cachetools==5.5.0
     # via google-auth
-certifi==2023.7.22
+certifi==2024.8.30
     # via
     #   httpcore
     #   httpx
     #   kubernetes
     #   requests
-cffi==1.15.1
+cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-charmed-kubeflow-chisme==0.4.2
+charmed-kubeflow-chisme==0.4.3
     # via -r requirements-integration.in
-charset-normalizer==3.2.0
+charset-normalizer==3.4.0
     # via requests
-cryptography==41.0.3
+cryptography==44.0.0
     # via paramiko
 decorator==5.1.1
     # via
@@ -50,68 +54,68 @@ decorator==5.1.1
     #   ipython
 deepdiff==6.2.1
     # via charmed-kubeflow-chisme
-exceptiongroup==1.1.3
+exceptiongroup==1.2.2
     # via
     #   anyio
     #   pytest
-executing==1.2.0
+executing==2.1.0
     # via stack-data
-frozenlist==1.4.0
+frozenlist==1.5.0
     # via
     #   aiohttp
     #   aiosignal
-google-auth==2.22.0
+google-auth==2.36.0
     # via kubernetes
 h11==0.14.0
     # via httpcore
-httpcore==0.17.3
+httpcore==1.0.7
     # via httpx
-httpx==0.24.1
+httpx==0.27.2
     # via lightkube
-hvac==1.2.0
+hvac==2.3.0
     # via juju
-idna==3.4
+idna==3.10
     # via
     #   anyio
     #   httpx
     #   requests
     #   yarl
-importlib-resources==6.4.0
+importlib-resources==6.4.5
     # via jsonschema
 iniconfig==2.0.0
     # via pytest
 ipdb==0.13.13
     # via pytest-operator
-ipython==8.12.2
+ipython==8.12.3
     # via ipdb
-jedi==0.19.0
+jedi==0.19.2
     # via ipython
-jinja2==3.1.2
+jinja2==3.1.4
     # via
     #   charmed-kubeflow-chisme
     #   pytest-operator
 jsonschema==4.17.3
     # via serialized-data-interface
-juju==3.4.0.0
+juju==3.6.0.0
     # via
     #   -r requirements-integration.in
     #   charmed-kubeflow-chisme
     #   pytest-operator
-kubernetes==27.2.0
+kubernetes==30.1.0
     # via juju
-lightkube==0.14.0
+lightkube==0.15.6
     # via
     #   -r requirements-integration.in
     #   charmed-kubeflow-chisme
-lightkube-models==1.28.1.4
+lightkube-models==1.31.1.8
     # via lightkube
-macaroonbakery==1.3.1
+macaroonbakery==1.3.4
     # via juju
-markupsafe==2.1.3
+markupsafe==2.1.5
     # via jinja2
-matplotlib-inline==0.1.6
+matplotlib-inline==0.1.7
     # via ipython
-multidict==6.0.4
+multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
@@ -121,49 +125,49 @@ oauthlib==3.2.2
     # via
     #   kubernetes
     #   requests-oauthlib
-ops==2.14.1
+ops==2.17.1
     # via
     #   charmed-kubeflow-chisme
     #   serialized-data-interface
 ordered-set==4.1.0
     # via deepdiff
-packaging==23.1
+packaging==24.2
     # via
     #   juju
     #   pytest
-paramiko==2.12.0
+paramiko==3.5.0
     # via juju
-parso==0.8.3
+parso==0.8.4
     # via jedi
-pexpect==4.8.0
+pexpect==4.9.0
     # via ipython
 pickleshare==0.7.5
     # via ipython
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-pluggy==1.3.0
+pluggy==1.5.0
     # via pytest
-prompt-toolkit==3.0.39
+prompt-toolkit==3.0.48
     # via ipython
-protobuf==3.20.3
+propcache==0.2.0
+    # via yarl
+protobuf==5.29.1
     # via macaroonbakery
 ptyprocess==0.7.0
     # via pexpect
-pure-eval==0.2.2
+pure-eval==0.2.3
     # via stack-data
-pyasn1==0.5.0
+pyasn1==0.6.1
     # via
     #   juju
     #   pyasn1-modules
     #   rsa
-pyasn1-modules==0.3.0
+pyasn1-modules==0.4.1
     # via google-auth
-pycparser==2.21
+pycparser==2.22
     # via cffi
-pygments==2.16.1
+pygments==2.18.0
     # via ipython
-pyhcl==0.4.5
-    # via hvac
 pymacaroons==0.13.0
     # via macaroonbakery
 pynacl==1.5.0
@@ -177,19 +181,19 @@ pyrfc3339==1.1
     #   macaroonbakery
 pyrsistent==0.20.0
     # via jsonschema
-pytest==7.4.2
+pytest==8.3.4
     # via
     #   pytest-asyncio
     #   pytest-operator
-pytest-asyncio==0.21.1
+pytest-asyncio==0.21.2
     # via pytest-operator
-pytest-operator==0.29.0
+pytest-operator==0.38.0
     # via -r requirements-integration.in
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
     # via kubernetes
-pytz==2023.3.post1
+pytz==2024.2
     # via pyrfc3339
-pyyaml==6.0.1
+pyyaml==6.0.2
     # via
     #   -r requirements-integration.in
     #   juju
@@ -198,14 +202,14 @@ pyyaml==6.0.1
     #   ops
     #   pytest-operator
     #   serialized-data-interface
-requests==2.31.0
+requests==2.32.3
     # via
     #   hvac
     #   kubernetes
     #   macaroonbakery
     #   requests-oauthlib
     #   serialized-data-interface
-requests-oauthlib==1.3.1
+requests-oauthlib==2.0.0
     # via kubernetes
 rsa==4.9
     # via google-auth
@@ -215,58 +219,56 @@ ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
 serialized-data-interface==0.7.0
     # via charmed-kubeflow-chisme
-six==1.16.0
+six==1.17.0
     # via
-    #   asttokens
-    #   google-auth
     #   kubernetes
     #   macaroonbakery
-    #   paramiko
     #   pymacaroons
     #   python-dateutil
-sniffio==1.3.0
+sniffio==1.3.1
     # via
     #   anyio
-    #   httpcore
     #   httpx
-soupsieve==2.5
+soupsieve==2.6
     # via beautifulsoup4
-stack-data==0.6.2
+stack-data==0.6.3
     # via ipython
-tenacity==8.2.3
+tenacity==9.0.0
     # via
     #   -r requirements-integration.in
     #   charmed-kubeflow-chisme
-tomli==2.0.1
+tomli==2.2.1
     # via
     #   ipdb
     #   pytest
 toposort==1.10
     # via juju
-traitlets==5.9.0
+traitlets==5.14.3
     # via
     #   ipython
     #   matplotlib-inline
-typing-extensions==4.7.1
+typing-extensions==4.12.2
     # via
+    #   anyio
     #   ipython
+    #   juju
+    #   multidict
     #   typing-inspect
 typing-inspect==0.9.0
     # via juju
-urllib3==1.26.16
+urllib3==2.2.3
     # via
-    #   google-auth
     #   kubernetes
     #   requests
-wcwidth==0.2.6
+wcwidth==0.2.13
     # via prompt-toolkit
-websocket-client==1.6.2
+websocket-client==1.8.0
     # via
     #   kubernetes
     #   ops
-websockets==12.0
+websockets==13.1
     # via juju
-yarl==1.9.2
+yarl==1.15.2
     # via aiohttp
-zipp==3.19.2
+zipp==3.20.2
     # via importlib-resources

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -4,43 +4,43 @@
 #
 #    pip-compile requirements-lint.in
 #
-black==24.4.2
+black==24.8.0
     # via -r requirements-lint.in
 click==8.1.7
     # via black
-codespell==2.2.5
+codespell==2.3.0
     # via -r requirements-lint.in
-flake8==6.0.0
+flake8==7.0.0
     # via
     #   -r requirements-lint.in
     #   flake8-builtins
     #   pep8-naming
     #   pyproject-flake8
-flake8-builtins==2.1.0
+flake8-builtins==2.5.0
     # via -r requirements-lint.in
 flake8-copyright==0.2.4
     # via -r requirements-lint.in
-isort==5.12.0
+isort==5.13.2
     # via -r requirements-lint.in
 mccabe==0.7.0
     # via flake8
 mypy-extensions==1.0.0
     # via black
-packaging==24.1
+packaging==24.2
     # via black
 pathspec==0.12.1
     # via black
-pep8-naming==0.13.3
+pep8-naming==0.14.1
     # via -r requirements-lint.in
-platformdirs==4.2.2
+platformdirs==4.3.6
     # via black
-pycodestyle==2.10.0
+pycodestyle==2.11.1
     # via flake8
-pyflakes==3.0.1
+pyflakes==3.2.0
     # via flake8
-pyproject-flake8==6.0.0.post1
+pyproject-flake8==7.0.0
     # via -r requirements-lint.in
-tomli==2.0.1
+tomli==2.2.1
     # via
     #   black
     #   pyproject-flake8

--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,8 @@ commands =
     bash -c 'for pattern in "requirements.in" "requirements-fmt.in" "requirements*.in"; do find . -type f -name "$pattern" -exec bash -c "cd \$(dirname "{}") && pip-compile --resolver=backtracking \$(basename "{}")" \;; done'
 deps =
     pip-tools
+    # Pin due to https://github.com/jazzband/pip-tools/issues/2131
+    pip==24.2
 description = Update requirements files by executing pip-compile on all requirements*.in files, including those in subdirs.
 
 [testenv:fmt]


### PR DESCRIPTION
* Pin pip to 24.2 due to https://github.com/jazzband/pip-tools/issues/2131
* Update python dependencies using 'tox -e update-requirements'

Ref canonical/bundle-kubeflow#1177