### PR TITLE
chore(ci): bump microk8s to 1.29-1.31

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -136,8 +136,8 @@ jobs:
     strategy:
       matrix:
         microk8s-versions:
-          - 1.25-strict/stable
-          - 1.26-strict/stable
+          - 1.31-strict/stable
+          - 1.31-strict/stable
     steps:
       - name: Check out repo
         uses: actions/checkout@v4

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -57,7 +57,6 @@ jobs:
       matrix:
         microk8s-versions:
           - 1.29-strict/stable
-          - 1.30-strict/stable
           - 1.31-strict/stable
         integration-types:
           - integration
@@ -134,12 +133,6 @@ jobs:
   integration-observability:
     name: Observability Integration Test
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        microk8s-versions:
-          - 1.29-strict/stable
-          - 1.30-strict/stable
-          - 1.31-strict/stable
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
@@ -148,7 +141,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
-          channel: ${{ matrix.microk8s-versions }}
+          channel: 1.31-strict/stable
           microk8s-addons: "dns hostpath-storage rbac metallb:10.64.140.43-10.64.140.49"
           juju-channel: 3.6/stable
           # Pinned to 3.x/stable due to https://github.com/canonical/charmcraft/issues/1845

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -55,6 +55,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
+        # We test with highest and lowest supported versions of k8s
         microk8s-versions:
           - 1.29-strict/stable
           - 1.31-strict/stable

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -56,8 +56,9 @@ jobs:
     strategy:
       matrix:
         microk8s-versions:
-          - 1.27-strict/stable
+          - 1.29-strict/stable
           - 1.30-strict/stable
+          - 1.31-strict/stable
         integration-types:
           - integration
           - integration-tls-provider
@@ -136,7 +137,8 @@ jobs:
     strategy:
       matrix:
         microk8s-versions:
-          - 1.31-strict/stable
+          - 1.29-strict/stable
+          - 1.30-strict/stable
           - 1.31-strict/stable
     steps:
       - name: Check out repo


### PR DESCRIPTION
Bump microk8s 1.29-1.31 according to https://github.com/kubeflow/community/issues/767#issuecomment-2593058929.

Ref canonical/bundle-kubeflow#1157