### PR TITLE
fix: build istio-pilot install istioctl

### DIFF
--- a/charms/istio-pilot/charmcraft.yaml
+++ b/charms/istio-pilot/charmcraft.yaml
@@ -64,6 +64,10 @@ parts:
       craftctl default
       # Include requirements.txt in *.charm artifact for easier debugging
       cp requirements.txt "$CRAFT_PART_INSTALL/requirements.txt"
+  istioctl:
+    plugin: dump
+    source: https://github.com/istio/istio/releases/download/1.22.0/istioctl-1.22.0-linux-amd64.tar.gz
+    source-type: tar
   # "files" part name is arbitrary; use for consistency
   files:
     plugin: dump


### PR DESCRIPTION
installs istioctl bin missed in https://github.com/canonical/charmed-kubeflow-solutions/pull/15

## Testing
1. Clone repo and checkout branch `fix-build-install-istioctl`
2. Make sure you're using charmcraft `latest/stable`
3. Pack charms
```
cd charms/istio-pilot
charmcraft pack -v

cd charms/istio-gateway
charmcraft pack -v
```
4. Deploy charms and add relations
```
cd charms/istio-pilot
juju deploy ./istio-pilot_ubuntu@20.04-amd64.charm --trust

cd charms/istio-gateway
juju deploy ./istio-gateway_ubuntu@20.04-amd64.charm istio-ingressgateway --config kind=ingress --trust

juju relate istio-pilot istio-ingressgateway
```
Expected output:
charms go to active
```
juju status

Model     Controller          Cloud/Region        Version  SLA          Timestamp
kubeflow  microk8s-localhost  microk8s/localhost  3.6.2    unsupported  11:16:15+02:00

App                   Version  Status  Scale  Charm          Channel  Rev  Address         Exposed  Message
istio-ingressgateway           active      1  istio-gateway             0  10.152.183.112  no       
istio-pilot                    active      1  istio-pilot               0  10.152.183.244  no       

Unit                     Workload  Agent  Address     Ports  Message
istio-ingressgateway/0*  active    idle   10.1.33.26         
istio-pilot/0*           active    idle   10.1.33.27  
```