### PR TITLE
(backport) chore: remove deprecation warning for the TLS secret configuration (#590)

### DIFF
--- a/charms/istio-pilot/README.md
+++ b/charms/istio-pilot/README.md
@@ -32,8 +32,6 @@ juju relate istio-pilot:certificates <TLS certificates providers>:certificates
 
 ### TLS cert and key
 
-⚠️ WARNING: This feature has been added due to #380, but will be supported only in 1.17 and 1.22 (and the versions released in between), after that, it will be removed in favour of integrating with a TLS certificates provider.
-
 > NOTE: this feature works with juju 3.4 and above.
 
 This charm allows TLS certificate and key files to configure the TLS ingress gateway.

--- a/charms/istio-pilot/src/charm.py
+++ b/charms/istio-pilot/src/charm.py
@@ -119,15 +119,9 @@ class Operator(CharmBase):
         # available, revoked, invalidated, or if the certs relation is broken
         self.framework.observe(self._cert_handler.on.cert_changed, self.reconcile)
 
-        # ---- Start of the block
-        # ---- WARNING: this feature is not recommended, but is supported in 1.17-1.22.
-        # ---- For details please refer to canonical/istio-operators#380.
-        # ---- FIXME: Remove this block after releasing 1.22.
         # Save TLS information and reconcile
         self._tls_secret_id = self.config.get("tls-secret-id")
         self.framework.observe(self.on.secret_changed, self.reconcile)
-
-        # ---- End of the block
 
         # Event handling for managing the Istio control plane
         self.framework.observe(self.on.install, self.install)
@@ -848,8 +842,6 @@ class Operator(CharmBase):
         otherwise, the information shared by a TLS certificate provider.
         """
 
-        # FIXME: remove the if statement and just return the dictionary that contains
-        # data from the CertHandler after 1.22
         if self._use_https_with_tls_secret():
             tls_secret = self.model.get_secret(id=self._tls_secret_id)
             return {
@@ -869,10 +861,6 @@ class Operator(CharmBase):
             ),
         }
 
-    # ---- Start of the block
-    # ---- WARNING: this feature is not recommended, but is supported in 1.17-1.22.
-    # ---- For details please refer to canonical/istio-operators#380.
-    # ---- FIXME: Remove this block after releasing 1.22.
     def _use_https(self) -> bool:
         """Return True if only one of the TLS configurations are enabled, False if none are.
 
@@ -952,8 +940,6 @@ class Operator(CharmBase):
 
     # ---- End of the block
 
-    # FIXME: Replace the below line with the one commented out after releasing 1.22
-    # def _use_https(self) -> bool:
     def _use_https_with_tls_provider(self) -> bool:
         """Return True if TLS key and cert are provided by a TLS cert provider, False otherwise.
 


### PR DESCRIPTION
Originally, the TLS configuration that's done by passing a juju secret to istio-pilot was expected to last only a few versions of this charm, but as exposed in #536, this feature is needed until there is a solution that fits out users/customer needs better. Because of that, this commit removes the comments and warnings about deprecating this feature.