### PR TITLE
ci: bumps checkout and upload-artifact versions v3 -> v4

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         charm: [pilot, gateway]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: sudo apt update && sudo apt install tox
       - run: tox -e ${{ matrix.charm }}-lint
 
@@ -37,7 +37,7 @@ jobs:
       matrix:
         charm: [pilot, gateway]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: sudo apt update && sudo apt install tox
       - run: tox -e ${{ matrix.charm }}-unit
 
@@ -63,7 +63,7 @@ jobs:
         uses: jlumbroso/free-disk-space@v1.3.1
 
       - name: Check out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
   
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
@@ -116,7 +116,7 @@ jobs:
 
       - name: Upload debug artifacts
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-run-artifacts
           path: tmp
@@ -131,7 +131,7 @@ jobs:
           - 1.26-strict/stable
     steps:
       - name: Check out repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -32,7 +32,7 @@ jobs:
     outputs:
       charm_paths_list: ${{ steps.get-charm-paths.outputs.CHARM_PATHS_LIST }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with: 
           fetch-depth: 0
           ref: ${{ inputs.source_branch }}
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ inputs.source_branch }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
     name: Promote charm
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Release charm to channel
         uses: canonical/charming-actions/release-charm@2.3.0
         with:


### PR DESCRIPTION
This commit bump the versions of those actions as they are now deprecated.