### PR TITLE
feat(gateway): add annotations configuration option for Service

### DIFF
--- a/charms/istio-gateway/config.yaml
+++ b/charms/istio-gateway/config.yaml
@@ -1,4 +1,15 @@
 options:
+  annotations:
+    default: ''
+    type: string
+    description: |
+      A comma-separated list of annotations to apply to the Ingress Service
+      to enable customisation for cloud providers or integrations.
+      The format should be: `key1=value1,key2=value2,key3=value3`.
+      For example:
+        "external-dns.alpha.kubernetes.io/hostname=example.com,service.beta.kubernetes.io/aws-load-balancer-type=nlb"
+      Please ensure you follow the rules in:
+        https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set
   kind:
     default: ''
     description: Kind of Istio gateway. Must be set to one of `ingress`, `egress`

--- a/charms/istio-gateway/src/charm.py
+++ b/charms/istio-gateway/src/charm.py
@@ -152,7 +152,7 @@ class Operator(CharmBase):
             pilot_port=pilot["service-port"],
             gateway_service_type=self.model.config["gateway_service_type"],
             replicas=self.model.config["replicas"],
-            annotations=self._worklod_service_annotations or {},
+            annotations=self._worklod_service_annotations,
         )
 
         for obj in codecs.load_all_yaml(rendered):

--- a/charms/istio-gateway/src/charm.py
+++ b/charms/istio-gateway/src/charm.py
@@ -28,6 +28,7 @@ METRICS_PORT = 9090
 # - Example invalid: "value@", "value#", "value space"
 ANNOTATION_KEY_MAX_LENGTH = 253
 ANNOTATION_VALUE_PATTERN = re.compile(r"^[\w.\-_]+$")
+ANNOTATION_KEY_START_WITH = ("kubernetes.io/", "k8s.io/")
 
 # Based on https://github.com/kubernetes/apimachinery/blob/v0.31.3/pkg/util/validation/validation.go#L204  # noqa
 # Regex for DNS1123 subdomains:
@@ -278,7 +279,7 @@ def validate_annotation_key(key: str) -> bool:
         logger.error(f"Invalid annotation key: '{key}'. Must follow Kubernetes annotation syntax.")
         return False
 
-    if key.startswith(("kubernetes.io/", "k8s.io/")):
+    if key.startswith(ANNOTATION_KEY_START_WITH):
         logger.error(f"Invalid annotation: Key '{key}' uses a reserved prefix.")
         return False
 

--- a/charms/istio-gateway/src/charm.py
+++ b/charms/istio-gateway/src/charm.py
@@ -83,7 +83,7 @@ class Operator(CharmBase):
         )
 
     @property
-    def _worklod_service_annotations(self) -> Optional[Dict[str, str]]:
+    def _workload_service_annotations(self) -> Optional[Dict[str, str]]:
         """Parse config and return dict of annotations for rendering the Workload Service.
 
         Annotations are passed as a configuration option in the form of key-value pairs,
@@ -152,7 +152,7 @@ class Operator(CharmBase):
             pilot_port=pilot["service-port"],
             gateway_service_type=self.model.config["gateway_service_type"],
             replicas=self.model.config["replicas"],
-            annotations=self._worklod_service_annotations,
+            annotations=self._workload_service_annotations,
         )
 
         for obj in codecs.load_all_yaml(rendered):

--- a/charms/istio-gateway/src/charm.py
+++ b/charms/istio-gateway/src/charm.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
 import logging
+import re
+from typing import Dict, Optional
 
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
 from jinja2 import Environment, FileSystemLoader
@@ -11,17 +13,46 @@ from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, StatusBase, WaitingStatus
 from serialized_data_interface import NoCompatibleVersions, NoVersionsListed, get_interfaces
 
+logger = logging.getLogger(__name__)
+
 SUPPORTED_GATEWAY_SERVICE_TYPES = ["LoadBalancer", "ClusterIP", "NodePort"]
 
 METRICS_PATH = "/stats/prometheus"
 METRICS_PORT = 9090
 
+# Regex for Kubernetes annotation values:
+# - Allows alphanumeric characters, dots (.), dashes (-), and underscores (_)
+# - Matches the entire string
+# - Does not allow empty strings
+# - Example valid: "value1", "my-value", "value.name", "value_name"
+# - Example invalid: "value@", "value#", "value space"
+ANNOTATION_VALUE_PATTERN = re.compile(r"^[\w.\-_]+$")
+
+# Based on https://github.com/kubernetes/apimachinery/blob/v0.31.3/pkg/util/validation/validation.go#L204  # noqa
+# Regex for DNS1123 subdomains:
+# - Starts with a lowercase letter or number ([a-z0-9])
+# - May contain dashes (-), but not consecutively, and must not start or end with them
+# - Segments can be separated by dots (.)
+# - Example valid: "example.com", "my-app.io", "sub.domain"
+# - Example invalid: "-example.com", "example..com", "example-.com"
+DNS1123_SUBDOMAIN_PATTERN = re.compile(
+    r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+)
+
+# Based on https://github.com/kubernetes/apimachinery/blob/v0.31.3/pkg/util/validation/validation.go#L32  # noqa
+# Regex for Kubernetes qualified names:
+# - Starts with an alphanumeric character ([A-Za-z0-9])
+# - Can include dashes (-), underscores (_), dots (.), or alphanumeric characters in the middle
+# - Ends with an alphanumeric character
+# - Must not be empty
+# - Example valid: "annotation", "my.annotation", "annotation-name"
+# - Example invalid: ".annotation", "annotation.", "-annotation", "annotation@key"
+QUALIFIED_NAME_PATTERN = re.compile(r"^[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$")
+
 
 class Operator(CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
-
-        self.log = logging.getLogger(__name__)
 
         # Every lightkube API call will use the model name as the namespace by default
         self.lightkube_client = Client(namespace=self.model.name, field_manager="lightkube")
@@ -50,6 +81,32 @@ class Operator(CharmBase):
                 }
             ],
         )
+
+    @property
+    def _worklod_service_annotations(self) -> Optional[Dict[str, str]]:
+        """Parse config and return dict of annotations for rendering the Workload Service.
+
+        Annotations are passed as a configuration option in the form of key-value pairs,
+        passed as a string to the charm: "key1=val1,key2=val2". This method manipulates
+        the string to return a Dictionary with valid annotations (one key per annotation).
+        """
+
+        annotations = self.model.config["annotations"]
+        if not annotations:
+            return None
+
+        annotations = annotations.strip().rstrip(",")
+        try:
+            dict_annotations = {
+                key.strip(): value.strip()
+                for key, value in (pair.split("=", 1) for pair in annotations.split(",") if pair)
+            }
+            return dict_annotations if valid_annotations(dict_annotations) else None
+        except ValueError:
+            logger.error(
+                "Invalid format for annotations. " "Expected format: key1=val1,key2=val2."
+            )
+            return None
 
     def start(self, event):
         """Event handler for StartEevnt."""
@@ -95,10 +152,11 @@ class Operator(CharmBase):
             pilot_port=pilot["service-port"],
             gateway_service_type=self.model.config["gateway_service_type"],
             replicas=self.model.config["replicas"],
+            annotations=self._worklod_service_annotations or {},
         )
 
         for obj in codecs.load_all_yaml(rendered):
-            self.log.debug(f"Deploying {obj.metadata.name} of kind {obj.kind}")
+            logger.debug(f"Deploying {obj.metadata.name} of kind {obj.kind}")
             self.lightkube_client.apply(obj, namespace=obj.metadata.namespace)
 
         self.unit.status = ActiveStatus()
@@ -123,16 +181,16 @@ class Operator(CharmBase):
                     type(obj), obj.metadata.name, namespace=obj.metadata.namespace
                 )
         except ApiError as err:
-            self.log.exception("ApiError encountered while attempting to delete resource.")
+            logger.exception("ApiError encountered while attempting to delete resource.")
             if err.status.message is not None:
                 if "(Unauthorized)" in err.status.message:
                     # Ignore error from https://bugs.launchpad.net/juju/+bug/1941655
-                    self.log.error(
+                    logger.error(
                         f"Ignoring unauthorized error during cleanup:" f"\n{err.status.message}"
                     )
                 else:
                     # But surface any other errors
-                    self.log.error(err.status.message)
+                    logger.error(err.status.message)
                     raise
             else:
                 raise
@@ -160,6 +218,69 @@ class CheckFailed(Exception):
         self.msg = str(msg)
         self.status_type = status_type
         self.status = status_type(self.msg)
+
+
+def valid_annotations(annotations: Dict[str, str]) -> bool:
+    """Return True if the annotations pass a series of checks, False otherwise.
+
+    Validate the annotations against the following checks:
+    * Length
+    * Annotation syntax
+    * Reserved prefixes
+
+    Args:
+      annotations (Dict[str,str]): dictionary with annotations
+    """
+    for key, value in annotations.items():
+        return validate_annotation_key(key) and validate_annotation_value(value)
+    return True
+
+
+def is_qualified_name(value: str) -> bool:
+    """Check if a value is a valid Kubernetes qualified name."""
+    parts = value.split("/")
+    if len(parts) > 2:
+        return False  # Invalid if more than one '/'
+
+    if len(parts) == 2:  # If prefixed
+        prefix, name = parts
+        if not prefix or not DNS1123_SUBDOMAIN_PATTERN.match(prefix):
+            return False
+    else:
+        name = parts[0]  # No prefix
+
+    if not name or len(name) > 63 or not QUALIFIED_NAME_PATTERN.match(name):
+        return False
+
+    return True
+
+
+def validate_annotation_value(value: str) -> bool:
+    """Validate the annotation value."""
+    if not ANNOTATION_VALUE_PATTERN.match(value):
+        logger.error(
+            f"Invalid annotation value: '{value}'. Must follow Kubernetes annotation syntax."
+        )
+        return False
+
+    return True
+
+
+def validate_annotation_key(key: str) -> bool:
+    """Validate the annotation key."""
+    if len(key) > 253:
+        logger.error(f"Invalid annotation key: '{key}'. Key length exceeds 253 characters.")
+        return False
+
+    if not is_qualified_name(key.lower()):
+        logger.error(f"Invalid annotation key: '{key}'. Must follow Kubernetes annotation syntax.")
+        return False
+
+    if key.startswith(("kubernetes.io/", "k8s.io/")):
+        logger.error(f"Invalid annotation: Key '{key}' uses a reserved prefix.")
+        return False
+
+    return True
 
 
 if __name__ == "__main__":

--- a/charms/istio-gateway/src/charm.py
+++ b/charms/istio-gateway/src/charm.py
@@ -26,6 +26,7 @@ METRICS_PORT = 9090
 # - Does not allow empty strings
 # - Example valid: "value1", "my-value", "value.name", "value_name"
 # - Example invalid: "value@", "value#", "value space"
+ANNOTATION_KEY_MAX_LENGTH = 253
 ANNOTATION_VALUE_PATTERN = re.compile(r"^[\w.\-_]+$")
 
 # Based on https://github.com/kubernetes/apimachinery/blob/v0.31.3/pkg/util/validation/validation.go#L204  # noqa
@@ -47,6 +48,7 @@ DNS1123_SUBDOMAIN_PATTERN = re.compile(
 # - Must not be empty
 # - Example valid: "annotation", "my.annotation", "annotation-name"
 # - Example invalid: ".annotation", "annotation.", "-annotation", "annotation@key"
+QUALIFIED_NAME_MAX_LENGTH = 63
 QUALIFIED_NAME_PATTERN = re.compile(r"^[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$")
 
 
@@ -249,7 +251,7 @@ def is_qualified_name(value: str) -> bool:
     else:
         name = parts[0]  # No prefix
 
-    if not name or len(name) > 63 or not QUALIFIED_NAME_PATTERN.match(name):
+    if not name or len(name) > QUALIFIED_NAME_MAX_LENGTH or not QUALIFIED_NAME_PATTERN.match(name):
         return False
 
     return True
@@ -268,7 +270,7 @@ def validate_annotation_value(value: str) -> bool:
 
 def validate_annotation_key(key: str) -> bool:
     """Validate the annotation key."""
-    if len(key) > 253:
+    if len(key) > ANNOTATION_KEY_MAX_LENGTH:
         logger.error(f"Invalid annotation key: '{key}'. Key length exceeds 253 characters.")
         return False
 

--- a/charms/istio-gateway/src/manifest.yaml
+++ b/charms/istio-gateway/src/manifest.yaml
@@ -296,6 +296,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+{% if annotations %}
+  annotations: {{ annotations }}
+{% endif %}
   labels:
     app: istio-{{ kind }}gateway
     install.operator.istio.io/owning-resource: unknown

--- a/charms/istio-gateway/tests/unit/test_annotation_validators.py
+++ b/charms/istio-gateway/tests/unit/test_annotation_validators.py
@@ -1,0 +1,86 @@
+import pytest
+
+from charm import (
+    is_qualified_name,
+    valid_annotations,
+    validate_annotation_key,
+    validate_annotation_value,
+)
+
+
+@pytest.mark.parametrize(
+    "value, expected_output",
+    (
+        ("something/invalid/api.io", False),
+        ("/something-invalid", False),
+        ("-invalid.com/fail", False),
+        ("invalid..com/fail", False),
+        ("invalid-.com/fail", False),
+        ("valid.com/pass", True),
+        ("valid.io/pass", True),
+        ("valid.domain/pass", True),
+        ("validname", True),
+        ("valid-name", True),
+        ("valid.name", True),
+        (".invalidname", False),
+        ("-invalidname", False),
+        ("invalid@name", False),
+        ("invalidname.", False),
+        ("invalid/", False),
+        ("/", False),
+        (
+            "eweizhf4i1ukpfot1jz14l3qzhjvsesa2e8egmjz4ushqblsei4f2bpgb287zteptxrk1u6rvjbjhugr8db7/",
+            False,
+        ),
+    ),
+)
+def test_is_qualified_name(value, expected_output):
+    """Ensure the is_qualified_name returns correct bool."""
+    assert is_qualified_name(value) == expected_output
+
+
+@pytest.mark.parametrize(
+    "annotations, expected_output",
+    (
+        ({"service.beta.kubernetes.io/mycloud-load-balancer-internal": "true"}, True),
+        ({"-service.beta.kubernetes.io/mycloud-load-balancer-internal": "true"}, False),
+        ({"key1": ""}, False),
+        ({"": ""}, False),
+    ),
+)
+def test_valid_annotations(annotations, expected_output):
+    """Ensure the valid_annotations returns correct bool."""
+    assert valid_annotations(annotations) == expected_output
+
+
+@pytest.mark.parametrize(
+    "value, expected_output",
+    (
+        ("valid-value", True),
+        ("validvalue1", True),
+        ("valid.value", True),
+        ("valid_value", True),
+        ("invalid value", False),
+        ("invalid!value", False),
+    ),
+)
+def test_validate_annotation_value(value, expected_output):
+    """Ensure the validate_annotation_value returns correct bool."""
+    assert validate_annotation_value(value) == expected_output
+
+
+@pytest.mark.parametrize(
+    "key, expected_output",
+    (
+        (
+            "ej8fep89xu3tdoj4ygn0lpfxl6r8bldf4ttleuocgsn8b772kxzkmwbsvma3sfzxc833c45j8us2bvg457hbnrp6l71dv68dktom8xki2sn4z3w4n7j5wbi8q80528ncalc2jizup3b8a9haa3racwu1dsq2m7zbfxkvgjx33d9xb7saeueirvjtk4n3tazg565ebihd7wr7uw9uw5skeu3yzxx4vqa5ivta1bkky61ot64xapmrhlbun61j83p0lb95at5me0vcsdjhrge55rwcjj9o9yf3rsquwkmdvfreg5d1w2n7mmhxgvsp",  # noqa
+            False,
+        ),
+        ("kubernetes.io/something-invalid", False),
+        ("k8s.io/something-invalid", False),
+        ("service.beta.kubernetes.io/mycloud-load-balancer-internal", True),
+    ),
+)
+def test_validate_annotation_key(key, expected_output):
+    """Ensure the validate_annotation_key returns correct bool."""
+    assert validate_annotation_key(key) == expected_output

--- a/charms/istio-gateway/tests/unit/test_charm.py
+++ b/charms/istio-gateway/tests/unit/test_charm.py
@@ -238,8 +238,8 @@ def test_manifests_applied_with_replicas_config(configured_harness, mocked_clien
     assert configured_harness.charm.model.unit.status == ActiveStatus("")
 
 
-def test__worklod_service_annotations(configured_harness, mocked_client):
-    """Ensure the _worklod_service_annotations property returns expected annotations."""
+def test__workload_service_annotations(configured_harness, mocked_client):
+    """Ensure the _workload_service_annotations property returns expected annotations."""
 
     # Arrange
     # Reset the mock so that the calls list does not include any calls from other hooks
@@ -253,4 +253,4 @@ def test__worklod_service_annotations(configured_harness, mocked_client):
     # Act
     configured_harness.charm.on.install.emit()
 
-    assert configured_harness.charm._worklod_service_annotations == expected_annotations
+    assert configured_harness.charm._workload_service_annotations == expected_annotations

--- a/charms/istio-gateway/tests/unit/test_charm.py
+++ b/charms/istio-gateway/tests/unit/test_charm.py
@@ -73,26 +73,6 @@ def test_start_apply(configured_harness, kind, mocked_client):
     assert configured_harness.charm.model.unit.status == ActiveStatus("")
 
 
-def test_apply_with_annotations(configured_harness, kind, mocked_client):
-    # Reset the mock so that the calls list does not include any calls from other hooks
-    mocked_client.reset_mock()
-
-    configured_harness.charm.on.start.emit()
-    actual_objects = []
-    expected_objects = list(yaml.safe_load_all(open(f"tests/unit/data/{kind}-example.yaml")))
-
-    # the apply method is called for every object in the manifest
-    for call in mocked_client.return_value.apply.call_args_list:
-        # Ensure the server side apply calls include the namespace kwarg
-        assert call.kwargs["namespace"] == "None"
-        # The first (and only) argument to the apply method is the obj
-        # Convert the object to a dictionary and add it to the list
-        actual_objects.append(call.args[0].to_dict())
-
-    assert expected_objects == actual_objects
-    assert configured_harness.charm.model.unit.status == ActiveStatus("")
-
-
 def test_removal(configured_harness, kind, mocked_client, mocker):
     mocked_client.reset_mock()
     configured_harness.charm.on.remove.emit()


### PR DESCRIPTION
With the annotations configuration option, users will be able to add annotations to the Gateway Workload Service on demand.

Fixes #66

NOTE: all credits to @IbraAoad on the validation checks for the annotations. This PR is based on https://github.com/canonical/traefik-k8s-operator/pull/428.

---

### Manual testing

1. Deploy `istio-pilot` (preferably from 1.24/stable)
2. Deploy `istio-gateway` from this PR and configure it as `ingress`:

```
juju deploy ./istio-gateway_ubuntu@20.04-amd64.charm istio-ingressgateway --config kind=ingress --trust
```

3. Check the `istio-ingressgateway-workload` does not contain any labels:

```
kubectl get svc -nistio-611 istio-ingressgateway-workload -oyaml
apiVersion: v1
kind: Service
metadata:
  creationTimestamp: "2025-04-16T01:45:51Z"
  labels:
    app: istio-ingressgateway
    app.juju.is/created-by: istio-ingressgateway
    install.operator.istio.io/owning-resource: unknown
    istio: ingressgateway
    istio.io/rev: default
    operator.istio.io/component: IngressGateways
    release: istio
  name: istio-ingressgateway-workload
  namespace: istio-611
```

4. Configure the `annotations` option and verify annotations are correctly applied:

```
juju config istio-ingressgateway annotations="service.beta.kubernetes.io/mycloud-load-balancer-internal=true"

kubectl get svc -nistio-611 istio-ingressgateway-workload -oyaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    service.beta.kubernetes.io/mycloud-load-balancer-internal: "true"
  creationTimestamp: "2025-04-16T01:45:51Z"
  labels:
    app: istio-ingressgateway
    app.juju.is/created-by: istio-ingressgateway
    install.operator.istio.io/owning-resource: unknown
    istio: ingressgateway
    istio.io/rev: default
    operator.istio.io/component: IngressGateways
    release: istio
  name: istio-ingressgateway-workload
  namespace: istio-611
```

5. (optional) You can also try passing invalid annotations. They should not be rendered and the error should be logged:

```
juju config istio-ingressgateway annotations="/service=true"

ubuntu@dev-noble:~/istio-operators/charms/istio-gateway$ kubectl get svc -nistio-611 istio-ingressgateway-workload -oyaml
apiVersion: v1
kind: Service
metadata:
  creationTimestamp: "2025-04-16T01:45:51Z"
  labels:
    app: istio-ingressgateway
    app.juju.is/created-by: istio-ingressgateway
    install.operator.istio.io/owning-resource: unknown
    istio: ingressgateway
    istio.io/rev: default
    operator.istio.io/component: IngressGateways
    release: istio
  name: istio-ingressgateway-workload
  namespace: istio-611

juju debug-log
...
unit-istio-ingressgateway-0: 20:04:16 ERROR unit.istio-ingressgateway/0.juju-log Invalid annotation key: '/service'. Must follow Kubernetes annotation syntax.
```