### PR TITLE
kf 7233 refactor test dependencies track branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,7 +112,7 @@ jobs:
         # We test with highest and lowest supported versions of k8s
         microk8s-versions:
           - 1.29-strict/stable
-          - 1.31-strict/stable
+          - 1.32-strict/stable
         integration-types:
           - integration
           - integration-tls-provider
@@ -213,7 +213,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
-          channel: 1.31-strict/stable
+          channel: 1.32-strict/stable
           microk8s-addons: "dns hostpath-storage rbac metallb:10.64.140.43-10.64.140.49"
           juju-channel: 3.6/stable
 

--- a/charms/istio-gateway/terraform/variables.tf
+++ b/charms/istio-gateway/terraform/variables.tf
@@ -7,7 +7,7 @@ variable "app_name" {
 variable "channel" {
   description = "Charm channel"
   type        = string
-  default     = null
+  default     = "1.24/stable"
 }
 
 variable "config" {

--- a/charms/istio-gateway/terraform/versions.tf
+++ b/charms/istio-gateway/terraform/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.14.0"
+      version = ">= 0.14.0"
     }
   }
 }

--- a/charms/istio-pilot/terraform/variables.tf
+++ b/charms/istio-pilot/terraform/variables.tf
@@ -7,7 +7,7 @@ variable "app_name" {
 variable "channel" {
   description = "Charm channel"
   type        = string
-  default     = null
+  default     = "1.24/stable"
 }
 
 variable "config" {

--- a/charms/istio-pilot/terraform/versions.tf
+++ b/charms/istio-pilot/terraform/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.14.0"
+      version = ">= 0.14.0"
     }
   }
 }

--- a/tests/dependencies.py
+++ b/tests/dependencies.py
@@ -1,0 +1,14 @@
+SELF_SIGNED_CERTIFICATES = "self-signed-certificates"
+SELF_SIGNED_CERTIFICATES_CHANNEL = "latest/edge"
+DEX_AUTH = "dex-auth"
+DEX_AUTH_CHANNEL = "latest/edge"
+DEX_AUTH_TRUST = True
+OIDC_GATEKEEPER = "oidc-gatekeeper"
+OIDC_GATEKEEPER_CHANNEL = "latest/edge"
+OIDC_GATEKEEPER_TRUST = False
+TENSORBOARD_CONTROLLER = "tensorboard-controller"
+TENSORBOARD_CONTROLLER_CHANNEL = "latest/edge"
+TENSORBOARD_CONTROLLER_TRUST = True
+KUBEFLOW_VOLUMES = "kubeflow-volumes"
+KUBEFLOW_VOLUMES_CHANNEL = "latest/edge"
+KUBEFLOW_VOLUMES_TRUST = True

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -15,24 +15,25 @@ from lightkube.generic_resource import (
     create_namespaced_resource,
     load_in_cluster_generic_resources,
 )
+from dependencies import (
+    DEX_AUTH,
+    DEX_AUTH_CHANNEL,
+    DEX_AUTH_TRUST,
+    OIDC_GATEKEEPER,
+    OIDC_GATEKEEPER_CHANNEL,
+    OIDC_GATEKEEPER_TRUST,
+    TENSORBOARD_CONTROLLER,
+    TENSORBOARD_CONTROLLER_CHANNEL,
+    TENSORBOARD_CONTROLLER_TRUST,
+    KUBEFLOW_VOLUMES,
+    KUBEFLOW_VOLUMES_CHANNEL,
+    KUBEFLOW_VOLUMES_TRUST,
+)
 from lightkube.resources.core_v1 import Pod
 from pytest_operator.plugin import OpsTest
 
 log = logging.getLogger(__name__)
 
-# Test dependencies
-DEX_AUTH = "dex-auth"
-DEX_AUTH_CHANNEL = "latest/edge"
-DEX_AUTH_TRUST = True
-OIDC_GATEKEEPER = "oidc-gatekeeper"
-OIDC_GATEKEEPER_CHANNEL = "latest/edge"
-OIDC_GATEKEEPER_TRUST = False
-TENSORBOARD_CONTROLLER = "tensorboard-controller"
-TENSORBOARD_CONTROLLER_CHANNEL = "latest/edge"
-TENSORBOARD_CONTROLLER_TRUST = True
-INGRESS_REQUIRER = "kubeflow-volumes"
-INGRESS_REQUIRER_CHANNEL = "latest/edge"
-INGRESS_REQUIRER_TRUST = True
 
 ISTIO_GATEWAY_METADATA = yaml.safe_load(Path("charms/istio-gateway/metadata.yaml").read_text())
 ISTIO_PILOT_METADATA = yaml.safe_load(Path("charms/istio-pilot/metadata.yaml").read_text())
@@ -126,11 +127,11 @@ async def test_ingress_relation(ops_test: OpsTest):
      specific charm that implements ingress's requirer interface to a generic charm
     """
     await ops_test.model.deploy(
-        INGRESS_REQUIRER, channel=INGRESS_REQUIRER_CHANNEL, trust=INGRESS_REQUIRER_TRUST
+        KUBEFLOW_VOLUMES, channel=KUBEFLOW_VOLUMES_CHANNEL, trust=KUBEFLOW_VOLUMES_TRUST
     )
 
     await ops_test.model.add_relation(
-        f"{ISTIO_PILOT_APP_NAME}:ingress", f"{INGRESS_REQUIRER}:ingress"
+        f"{ISTIO_PILOT_APP_NAME}:ingress", f"{KUBEFLOW_VOLUMES}:ingress"
     )
 
     await ops_test.model.wait_for_idle(
@@ -139,7 +140,7 @@ async def test_ingress_relation(ops_test: OpsTest):
         timeout=90 * 10,
     )
 
-    assert_virtualservice_exists(name=INGRESS_REQUIRER, namespace=ops_test.model_name)
+    assert_virtualservice_exists(name=KUBEFLOW_VOLUMES, namespace=ops_test.model_name)
 
     # Confirm that the UI is reachable through the ingress
     gateway_ip = await get_gateway_ip(ops_test)

--- a/tests/test_bundle_tls_provider.py
+++ b/tests/test_bundle_tls_provider.py
@@ -6,6 +6,10 @@ import tenacity
 import yaml
 from lightkube.generic_resource import create_namespaced_resource
 from lightkube.resources.core_v1 import Secret
+from dependencies import (
+    SELF_SIGNED_CERTIFICATES,
+    SELF_SIGNED_CERTIFICATES_CHANNEL
+)
 from pytest_operator.plugin import OpsTest
 
 ISTIO_GATEWAY_METADATA = yaml.safe_load(Path("charms/istio-gateway/metadata.yaml").read_text())
@@ -19,10 +23,6 @@ GATEWAY_RESOURCE = create_namespaced_resource(
     kind="Gateway",
     plural="gateways",
 )
-
-SELF_SIGNED_CERTIFICATES = "self-signed-certificates"
-SELF_SIGNED_CERTIFICATES_CHANNEL = "latest/edge"
-SELF_SIGNED_CERTIFICATES_TRUST = True
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
- **fix(tls): use cert_subject in the sans and cert_subject fields (#614)**
- **[KF-7254] Release 1.10 (#612)**
- **tests: Move charms-dependencies in dependencies.py**


[KF-7254]: https://warthogs.atlassian.net/browse/KF-7254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ