### PR TITLE
tests: Move charms-dependencies in dependencies.py

### DIFF
--- a/tests/dependencies.py
+++ b/tests/dependencies.py
@@ -1,0 +1,14 @@
+SELF_SIGNED_CERTIFICATES = "self-signed-certificates"
+SELF_SIGNED_CERTIFICATES_CHANNEL = "latest/edge"
+DEX_AUTH = "dex-auth"
+DEX_AUTH_CHANNEL = "latest/edge"
+DEX_AUTH_TRUST = True
+OIDC_GATEKEEPER = "oidc-gatekeeper"
+OIDC_GATEKEEPER_CHANNEL = "latest/edge"
+OIDC_GATEKEEPER_TRUST = False
+TENSORBOARD_CONTROLLER = "tensorboard-controller"
+TENSORBOARD_CONTROLLER_CHANNEL = "latest/edge"
+TENSORBOARD_CONTROLLER_TRUST = True
+KUBEFLOW_VOLUMES = "kubeflow-volumes"
+KUBEFLOW_VOLUMES_CHANNEL = "latest/edge"
+KUBEFLOW_VOLUMES_TRUST = True

--- a/tests/test_bundle_tls_provider.py
+++ b/tests/test_bundle_tls_provider.py
@@ -4,6 +4,7 @@ import lightkube
 import pytest
 import tenacity
 import yaml
+from dependencies import SELF_SIGNED_CERTIFICATES, SELF_SIGNED_CERTIFICATES_CHANNEL
 from lightkube.generic_resource import create_namespaced_resource
 from lightkube.resources.core_v1 import Secret
 from pytest_operator.plugin import OpsTest
@@ -19,10 +20,6 @@ GATEWAY_RESOURCE = create_namespaced_resource(
     kind="Gateway",
     plural="gateways",
 )
-
-SELF_SIGNED_CERTIFICATES = "self-signed-certificates"
-SELF_SIGNED_CERTIFICATES_CHANNEL = "latest/edge"
-SELF_SIGNED_CERTIFICATES_TRUST = True
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Keep charms-dependencies that are deployed during integration in a distinct
dependencies.py file to enable managing them automatically.

Ref canonical/bundle-kubeflow#1256
