### PR TITLE
backport: fix for #66 and setuptools_scm constraints

### DIFF
--- a/charms/istio-gateway/charmcraft.yaml
+++ b/charms/istio-gateway/charmcraft.yaml
@@ -38,6 +38,8 @@ parts:
     after:
       - python-deps
     python-requirements: [requirements.txt]
+    build-environment:
+      - PIP_CONSTRAINT: constraints.txt
     build-packages:
       - libffi-dev  # Needed to build Python dependencies with Rust from source
       - libssl-dev  # Needed to build Python dependencies with Rust from source
@@ -61,6 +63,7 @@ parts:
       # Ubuntu 22.04 archive. Install rustc and cargo using rustup instead of the Ubuntu archive
       rustup set profile minimal
       rustup default 1.83.0  # renovate: charmcraft-rust-latest
+
       craftctl default
       # Include requirements.txt in *.charm artifact for easier debugging
       cp requirements.txt "$CRAFT_PART_INSTALL/requirements.txt"

--- a/charms/istio-gateway/config.yaml
+++ b/charms/istio-gateway/config.yaml
@@ -1,4 +1,15 @@
 options:
+  annotations:
+    default: ''
+    type: string
+    description: |
+      A comma-separated list of annotations to apply to the Ingress Service
+      to enable customisation for cloud providers or integrations.
+      The format should be: `key1=value1,key2=value2,key3=value3`.
+      For example:
+        "external-dns.alpha.kubernetes.io/hostname=example.com,service.beta.kubernetes.io/aws-load-balancer-type=nlb"
+      Please ensure you follow the rules in:
+        https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set
   kind:
     default: ''
     description: Kind of Istio gateway. Must be set to one of `ingress`, `egress`

--- a/charms/istio-gateway/constraints.txt
+++ b/charms/istio-gateway/constraints.txt
@@ -1,0 +1,1 @@
+setuptools_scm < 8.2.0; python_version < "3.10"

--- a/charms/istio-gateway/src/charm.py
+++ b/charms/istio-gateway/src/charm.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
 import logging
+import re
+from typing import Dict, Optional
 
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
 from jinja2 import Environment, FileSystemLoader
@@ -11,17 +13,49 @@ from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, StatusBase, WaitingStatus
 from serialized_data_interface import NoCompatibleVersions, NoVersionsListed, get_interfaces
 
+logger = logging.getLogger(__name__)
+
 SUPPORTED_GATEWAY_SERVICE_TYPES = ["LoadBalancer", "ClusterIP", "NodePort"]
 
 METRICS_PATH = "/stats/prometheus"
 METRICS_PORT = 9090
 
+# Regex for Kubernetes annotation values:
+# - Allows alphanumeric characters, dots (.), dashes (-), and underscores (_)
+# - Matches the entire string
+# - Does not allow empty strings
+# - Example valid: "value1", "my-value", "value.name", "value_name"
+# - Example invalid: "value@", "value#", "value space"
+ANNOTATION_KEY_MAX_LENGTH = 253
+ANNOTATION_VALUE_PATTERN = re.compile(r"^[\w.\-_]+$")
+ANNOTATION_KEY_START_WITH = ("kubernetes.io/", "k8s.io/")
+
+# Based on https://github.com/kubernetes/apimachinery/blob/v0.31.3/pkg/util/validation/validation.go#L204  # noqa
+# Regex for DNS1123 subdomains:
+# - Starts with a lowercase letter or number ([a-z0-9])
+# - May contain dashes (-), but not consecutively, and must not start or end with them
+# - Segments can be separated by dots (.)
+# - Example valid: "example.com", "my-app.io", "sub.domain"
+# - Example invalid: "-example.com", "example..com", "example-.com"
+DNS1123_SUBDOMAIN_PATTERN = re.compile(
+    r"^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+)
+
+# Based on https://github.com/kubernetes/apimachinery/blob/v0.31.3/pkg/util/validation/validation.go#L32  # noqa
+# Regex for Kubernetes qualified names:
+# - Starts with an alphanumeric character ([A-Za-z0-9])
+# - Can include dashes (-), underscores (_), dots (.), or alphanumeric characters in the middle
+# - Ends with an alphanumeric character
+# - Must not be empty
+# - Example valid: "annotation", "my.annotation", "annotation-name"
+# - Example invalid: ".annotation", "annotation.", "-annotation", "annotation@key"
+QUALIFIED_NAME_MAX_LENGTH = 63
+QUALIFIED_NAME_PATTERN = re.compile(r"^[A-Za-z0-9]([-A-Za-z0-9_.]*[A-Za-z0-9])?$")
+
 
 class Operator(CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
-
-        self.log = logging.getLogger(__name__)
 
         # Every lightkube API call will use the model name as the namespace by default
         self.lightkube_client = Client(namespace=self.model.name, field_manager="lightkube")
@@ -50,6 +84,32 @@ class Operator(CharmBase):
                 }
             ],
         )
+
+    @property
+    def _workload_service_annotations(self) -> Optional[Dict[str, str]]:
+        """Parse config and return dict of annotations for rendering the Workload Service.
+
+        Annotations are passed as a configuration option in the form of key-value pairs,
+        passed as a string to the charm: "key1=val1,key2=val2". This method manipulates
+        the string to return a Dictionary with valid annotations (one key per annotation).
+        """
+
+        annotations = self.model.config["annotations"]
+        if not annotations:
+            return None
+
+        annotations = annotations.strip().rstrip(",")
+        try:
+            dict_annotations = {
+                key.strip(): value.strip()
+                for key, value in (pair.split("=", 1) for pair in annotations.split(",") if pair)
+            }
+            return dict_annotations if valid_annotations(dict_annotations) else None
+        except ValueError:
+            logger.error(
+                "Invalid format for annotations. " "Expected format: key1=val1,key2=val2."
+            )
+            return None
 
     def start(self, event):
         """Event handler for StartEevnt."""
@@ -95,10 +155,11 @@ class Operator(CharmBase):
             pilot_port=pilot["service-port"],
             gateway_service_type=self.model.config["gateway_service_type"],
             replicas=self.model.config["replicas"],
+            annotations=self._workload_service_annotations,
         )
 
         for obj in codecs.load_all_yaml(rendered):
-            self.log.debug(f"Deploying {obj.metadata.name} of kind {obj.kind}")
+            logger.debug(f"Deploying {obj.metadata.name} of kind {obj.kind}")
             self.lightkube_client.apply(obj, namespace=obj.metadata.namespace)
 
         self.unit.status = ActiveStatus()
@@ -123,16 +184,16 @@ class Operator(CharmBase):
                     type(obj), obj.metadata.name, namespace=obj.metadata.namespace
                 )
         except ApiError as err:
-            self.log.exception("ApiError encountered while attempting to delete resource.")
+            logger.exception("ApiError encountered while attempting to delete resource.")
             if err.status.message is not None:
                 if "(Unauthorized)" in err.status.message:
                     # Ignore error from https://bugs.launchpad.net/juju/+bug/1941655
-                    self.log.error(
+                    logger.error(
                         f"Ignoring unauthorized error during cleanup:" f"\n{err.status.message}"
                     )
                 else:
                     # But surface any other errors
-                    self.log.error(err.status.message)
+                    logger.error(err.status.message)
                     raise
             else:
                 raise
@@ -160,6 +221,69 @@ class CheckFailed(Exception):
         self.msg = str(msg)
         self.status_type = status_type
         self.status = status_type(self.msg)
+
+
+def valid_annotations(annotations: Dict[str, str]) -> bool:
+    """Return True if the annotations pass a series of checks, False otherwise.
+
+    Validate the annotations against the following checks:
+    * Length
+    * Annotation syntax
+    * Reserved prefixes
+
+    Args:
+      annotations (Dict[str,str]): dictionary with annotations
+    """
+    for key, value in annotations.items():
+        return validate_annotation_key(key) and validate_annotation_value(value)
+    return True
+
+
+def is_qualified_name(value: str) -> bool:
+    """Check if a value is a valid Kubernetes qualified name."""
+    parts = value.split("/")
+    if len(parts) > 2:
+        return False  # Invalid if more than one '/'
+
+    if len(parts) == 2:  # If prefixed
+        prefix, name = parts
+        if not prefix or not DNS1123_SUBDOMAIN_PATTERN.match(prefix):
+            return False
+    else:
+        name = parts[0]  # No prefix
+
+    if not name or len(name) > QUALIFIED_NAME_MAX_LENGTH or not QUALIFIED_NAME_PATTERN.match(name):
+        return False
+
+    return True
+
+
+def validate_annotation_value(value: str) -> bool:
+    """Validate the annotation value."""
+    if not ANNOTATION_VALUE_PATTERN.match(value):
+        logger.error(
+            f"Invalid annotation value: '{value}'. Must follow Kubernetes annotation syntax."
+        )
+        return False
+
+    return True
+
+
+def validate_annotation_key(key: str) -> bool:
+    """Validate the annotation key."""
+    if len(key) > ANNOTATION_KEY_MAX_LENGTH:
+        logger.error(f"Invalid annotation key: '{key}'. Key length exceeds 253 characters.")
+        return False
+
+    if not is_qualified_name(key.lower()):
+        logger.error(f"Invalid annotation key: '{key}'. Must follow Kubernetes annotation syntax.")
+        return False
+
+    if key.startswith(ANNOTATION_KEY_START_WITH):
+        logger.error(f"Invalid annotation: Key '{key}' uses a reserved prefix.")
+        return False
+
+    return True
 
 
 if __name__ == "__main__":

--- a/charms/istio-gateway/src/manifest.yaml
+++ b/charms/istio-gateway/src/manifest.yaml
@@ -296,6 +296,9 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
+{% if annotations %}
+  annotations: {{ annotations }}
+{% endif %}
   labels:
     app: istio-{{ kind }}gateway
     install.operator.istio.io/owning-resource: unknown

--- a/charms/istio-gateway/tests/unit/test_annotation_validators.py
+++ b/charms/istio-gateway/tests/unit/test_annotation_validators.py
@@ -1,0 +1,86 @@
+import pytest
+
+from charm import (
+    is_qualified_name,
+    valid_annotations,
+    validate_annotation_key,
+    validate_annotation_value,
+)
+
+
+@pytest.mark.parametrize(
+    "value, expected_output",
+    (
+        ("something/invalid/api.io", False),
+        ("/something-invalid", False),
+        ("-invalid.com/fail", False),
+        ("invalid..com/fail", False),
+        ("invalid-.com/fail", False),
+        ("valid.com/pass", True),
+        ("valid.io/pass", True),
+        ("valid.domain/pass", True),
+        ("validname", True),
+        ("valid-name", True),
+        ("valid.name", True),
+        (".invalidname", False),
+        ("-invalidname", False),
+        ("invalid@name", False),
+        ("invalidname.", False),
+        ("invalid/", False),
+        ("/", False),
+        (
+            "eweizhf4i1ukpfot1jz14l3qzhjvsesa2e8egmjz4ushqblsei4f2bpgb287zteptxrk1u6rvjbjhugr8db7/",
+            False,
+        ),
+    ),
+)
+def test_is_qualified_name(value, expected_output):
+    """Ensure the is_qualified_name returns correct bool."""
+    assert is_qualified_name(value) == expected_output
+
+
+@pytest.mark.parametrize(
+    "annotations, expected_output",
+    (
+        ({"service.beta.kubernetes.io/mycloud-load-balancer-internal": "true"}, True),
+        ({"-service.beta.kubernetes.io/mycloud-load-balancer-internal": "true"}, False),
+        ({"key1": ""}, False),
+        ({"": ""}, False),
+    ),
+)
+def test_valid_annotations(annotations, expected_output):
+    """Ensure the valid_annotations returns correct bool."""
+    assert valid_annotations(annotations) == expected_output
+
+
+@pytest.mark.parametrize(
+    "value, expected_output",
+    (
+        ("valid-value", True),
+        ("validvalue1", True),
+        ("valid.value", True),
+        ("valid_value", True),
+        ("invalid value", False),
+        ("invalid!value", False),
+    ),
+)
+def test_validate_annotation_value(value, expected_output):
+    """Ensure the validate_annotation_value returns correct bool."""
+    assert validate_annotation_value(value) == expected_output
+
+
+@pytest.mark.parametrize(
+    "key, expected_output",
+    (
+        (
+            "ej8fep89xu3tdoj4ygn0lpfxl6r8bldf4ttleuocgsn8b772kxzkmwbsvma3sfzxc833c45j8us2bvg457hbnrp6l71dv68dktom8xki2sn4z3w4n7j5wbi8q80528ncalc2jizup3b8a9haa3racwu1dsq2m7zbfxkvgjx33d9xb7saeueirvjtk4n3tazg565ebihd7wr7uw9uw5skeu3yzxx4vqa5ivta1bkky61ot64xapmrhlbun61j83p0lb95at5me0vcsdjhrge55rwcjj9o9yf3rsquwkmdvfreg5d1w2n7mmhxgvsp",  # noqa
+            False,
+        ),
+        ("kubernetes.io/something-invalid", False),
+        ("k8s.io/something-invalid", False),
+        ("service.beta.kubernetes.io/mycloud-load-balancer-internal", True),
+    ),
+)
+def test_validate_annotation_key(key, expected_output):
+    """Ensure the validate_annotation_key returns correct bool."""
+    assert validate_annotation_key(key) == expected_output

--- a/charms/istio-gateway/tests/unit/test_charm.py
+++ b/charms/istio-gateway/tests/unit/test_charm.py
@@ -236,3 +236,21 @@ def test_manifests_applied_with_replicas_config(configured_harness, mocked_clien
     # Assert
     assert gateway_deployment["spec"].get("replicas") == replicas_config_value
     assert configured_harness.charm.model.unit.status == ActiveStatus("")
+
+
+def test__workload_service_annotations(configured_harness, mocked_client):
+    """Ensure the _workload_service_annotations property returns expected annotations."""
+
+    # Arrange
+    # Reset the mock so that the calls list does not include any calls from other hooks
+    mocked_client.reset_mock()
+
+    configured_harness.update_config(
+        {"annotations": "service.beta.kubernetes.io/mycloud-load-balancer-internal=true"}
+    )
+    expected_annotations = {"service.beta.kubernetes.io/mycloud-load-balancer-internal": "true"}
+
+    # Act
+    configured_harness.charm.on.install.emit()
+
+    assert configured_harness.charm._workload_service_annotations == expected_annotations

--- a/charms/istio-pilot/charmcraft.yaml
+++ b/charms/istio-pilot/charmcraft.yaml
@@ -38,11 +38,14 @@ parts:
     after:
       - python-deps
     python-requirements: [requirements.txt]
+    build-environment:
+      - PIP_CONSTRAINT: constraints.txt
     build-packages:
       - libffi-dev  # Needed to build Python dependencies with Rust from source
       - libssl-dev  # Needed to build Python dependencies with Rust from source
       - pkg-config  # Needed to build Python dependencies with Rust from source
     override-build: |
+
       # Workaround for https://github.com/canonical/charmcraft/issues/2068
       # rustup used to install rustc and cargo, which are needed to build Python dependencies with Rust from source
       if [[ "$CRAFT_PLATFORM" == ubuntu@20.04:* || "$CRAFT_PLATFORM" == ubuntu@22.04:* ]]
@@ -61,7 +64,9 @@ parts:
       # Ubuntu 22.04 archive. Install rustc and cargo using rustup instead of the Ubuntu archive
       rustup set profile minimal
       rustup default 1.83.0  # renovate: charmcraft-rust-latest
+
       craftctl default
+
       # Include requirements.txt in *.charm artifact for easier debugging
       cp requirements.txt "$CRAFT_PART_INSTALL/requirements.txt"
   istioctl:

--- a/charms/istio-pilot/constraints.txt
+++ b/charms/istio-pilot/constraints.txt
@@ -1,0 +1,1 @@
+setuptools_scm < 8.2.0; python_version < "3.10"


### PR DESCRIPTION
This PR is a backport of:

* feat(gateway): add annotations configuration option for Service (#611)
* fix(workaround): set constraints to setuptools-scm to avoid install loops (#618)