### PR TITLE
refactor(tests): Move dependency charms to a separate file

### DIFF
--- a/requirements-integration.txt
+++ b/requirements-integration.txt
@@ -42,7 +42,7 @@ cffi==1.17.1
     # via
     #   cryptography
     #   pynacl
-charmed-kubeflow-chisme==0.4.3
+charmed-kubeflow-chisme==0.4.9
     # via -r requirements-integration.in
 charset-normalizer==3.4.0
     # via requests
@@ -71,7 +71,9 @@ h11==0.14.0
 httpcore==1.0.7
     # via httpx
 httpx==0.27.2
-    # via lightkube
+    # via
+    #   charmed-kubeflow-chisme
+    #   lightkube
 hvac==2.3.0
     # via juju
 idna==3.10

--- a/tests/charms_dependencies.py
+++ b/tests/charms_dependencies.py
@@ -1,0 +1,29 @@
+"""Charms dependencies for tests."""
+
+from charmed_kubeflow_chisme.testing import CharmSpec
+
+SELF_SIGNED_CERTIFICATES = CharmSpec(
+    charm="self-signed-certificates",
+    channel="latest/edge",
+    trust=True,
+)
+DEX_AUTH = CharmSpec(
+    charm="dex-auth",
+    channel="latest/edge",
+    trust=True,
+)
+OIDC_GATEKEEPER = CharmSpec(
+    charm="oidc-gatekeeper",
+    channel="latest/edge",
+    trust=True,
+)
+TENSORBOARD_CONTROLLER = CharmSpec(
+    charm="tensorboard-controller",
+    channel="latest/edge",
+    trust=True,
+)
+KUBEFLOW_VOLUMES = CharmSpec(
+    charm="kubeflow-volumes",
+    channel="latest/edge",
+    trust=True,
+)

--- a/tests/test_bundle_tls_provider.py
+++ b/tests/test_bundle_tls_provider.py
@@ -4,6 +4,7 @@ import lightkube
 import pytest
 import tenacity
 import yaml
+from charms_dependencies import SELF_SIGNED_CERTIFICATES
 from lightkube.generic_resource import create_namespaced_resource
 from lightkube.resources.core_v1 import Secret
 from pytest_operator.plugin import OpsTest
@@ -19,10 +20,6 @@ GATEWAY_RESOURCE = create_namespaced_resource(
     kind="Gateway",
     plural="gateways",
 )
-
-SELF_SIGNED_CERTIFICATES = "self-signed-certificates"
-SELF_SIGNED_CERTIFICATES_CHANNEL = "latest/edge"
-SELF_SIGNED_CERTIFICATES_TRUST = True
 
 
 @pytest.fixture(scope="session")
@@ -72,12 +69,12 @@ async def test_build_and_deploy_istio_charms(ops_test: OpsTest, request):
     )
 
     await ops_test.model.deploy(
-        SELF_SIGNED_CERTIFICATES,
-        channel=SELF_SIGNED_CERTIFICATES_CHANNEL,
+        SELF_SIGNED_CERTIFICATES.charm,
+        channel=SELF_SIGNED_CERTIFICATES.channel,
     )
 
     await ops_test.model.add_relation(
-        f"{ISTIO_PILOT_APP_NAME}:certificates", f"{SELF_SIGNED_CERTIFICATES}:certificates"
+        f"{ISTIO_PILOT_APP_NAME}:certificates", f"{SELF_SIGNED_CERTIFICATES.charm}:certificates"
     )
 
     await ops_test.model.wait_for_idle(


### PR DESCRIPTION
Move dependency charms deployed during tests to a separate file called
charms_dependencies.py. This enables programmatic access to them and
thus updating them centrally, probably with the use of `kfcicli`. This
uses the `CharmSpec` dataclass from chisme.

Ref canonical/bundle-kubeflow/issues/1256
