### PR TITLE
chore: Pin charm base to 24.04 in Terraform module and `release-charm` actions

### DIFF
--- a/charms/istio-gateway/terraform/main.tf
+++ b/charms/istio-gateway/terraform/main.tf
@@ -1,6 +1,7 @@
 resource "juju_application" "istio_gateway" {
   charm {
     name     = "istio-gateway"
+    base     = var.base
     channel  = var.channel
     revision = var.revision
   }

--- a/charms/istio-gateway/terraform/variables.tf
+++ b/charms/istio-gateway/terraform/variables.tf
@@ -4,6 +4,12 @@ variable "app_name" {
   default     = "istio-gateway"
 }
 
+variable "base" {
+  description = "Application base"
+  type        = string
+  default     = "ubuntu@24.04"
+}
+
 variable "channel" {
   description = "Charm channel"
   type        = string

--- a/charms/istio-pilot/terraform/main.tf
+++ b/charms/istio-pilot/terraform/main.tf
@@ -1,6 +1,7 @@
 resource "juju_application" "istio_pilot" {
   charm {
     name     = "istio-pilot"
+    base     = var.base
     channel  = var.channel
     revision = var.revision
   }

--- a/charms/istio-pilot/terraform/variables.tf
+++ b/charms/istio-pilot/terraform/variables.tf
@@ -4,6 +4,12 @@ variable "app_name" {
   default     = "istio-pilot"
 }
 
+variable "base" {
+  description = "Application base"
+  type        = string
+  default     = "ubuntu@24.04"
+}
+
 variable "channel" {
   description = "Charm channel"
   type        = string


### PR DESCRIPTION
Ref: https://github.com/canonical/bundle-kubeflow/issues/1347

This PR:
- Updates the default base in the Terraform modules to `24.04`.
- Pins the base in the `release-charm` action to `24.04`, to override the default value of `20.04`
