### PR TITLE
chore: Pin charm base to 24.04 in Terraform module and `release-charm` actions

### DIFF
--- a/charms/istio-gateway/terraform/README.md
+++ b/charms/istio-gateway/terraform/README.md
@@ -13,6 +13,7 @@ The module offers the following configurable inputs:
 | Name | Type | Description | Required |
 | - | - | - | - |
 | `app_name`| string | Application name | False |
+| `base`| string | Charm base | False |
 | `channel`| string | Channel that the charm is deployed from | False |
 | `config`| map(string) | Map of the charm configuration options | False |
 | `model_name`| string | Name of the model that the charm is deployed on | True |

--- a/charms/istio-gateway/terraform/main.tf
+++ b/charms/istio-gateway/terraform/main.tf
@@ -1,6 +1,7 @@
 resource "juju_application" "istio_gateway" {
   charm {
     name     = "istio-gateway"
+    base     = var.base
     channel  = var.channel
     revision = var.revision
   }

--- a/charms/istio-gateway/terraform/variables.tf
+++ b/charms/istio-gateway/terraform/variables.tf
@@ -4,6 +4,12 @@ variable "app_name" {
   default     = "istio-gateway"
 }
 
+variable "base" {
+  description = "Charm base"
+  type        = string
+  default     = "ubuntu@24.04"
+}
+
 variable "channel" {
   description = "Charm channel"
   type        = string

--- a/charms/istio-pilot/terraform/README.md
+++ b/charms/istio-pilot/terraform/README.md
@@ -13,6 +13,7 @@ The module offers the following configurable inputs:
 | Name | Type | Description | Required |
 | - | - | - | - |
 | `app_name`| string | Application name | False |
+| `base`| string | Charm base | False |
 | `channel`| string | Channel that the charm is deployed from | False |
 | `config`| map(string) | Map of the charm configuration options | False |
 | `model_name`| string | Name of the model that the charm is deployed on | True |

--- a/charms/istio-pilot/terraform/main.tf
+++ b/charms/istio-pilot/terraform/main.tf
@@ -1,6 +1,7 @@
 resource "juju_application" "istio_pilot" {
   charm {
     name     = "istio-pilot"
+    base     = var.base
     channel  = var.channel
     revision = var.revision
   }

--- a/charms/istio-pilot/terraform/variables.tf
+++ b/charms/istio-pilot/terraform/variables.tf
@@ -4,6 +4,12 @@ variable "app_name" {
   default     = "istio-pilot"
 }
 
+variable "base" {
+  description = "Charm base"
+  type        = string
+  default     = "ubuntu@24.04"
+}
+
 variable "channel" {
   description = "Charm channel"
   type        = string


### PR DESCRIPTION
Ref: https://github.com/canonical/bundle-kubeflow/issues/1347

This PR is a backport of #653.