### PR TITLE
chore: pin charm dependencies in tests (track/1.27)

### DIFF
--- a/tests/charms_dependencies.py
+++ b/tests/charms_dependencies.py
@@ -9,21 +9,21 @@ SELF_SIGNED_CERTIFICATES = CharmSpec(
 )
 DEX_AUTH = CharmSpec(
     charm="dex-auth",
-    channel="latest/edge",
+    channel="2.41/edge",
     trust=True,
 )
 OIDC_GATEKEEPER = CharmSpec(
     charm="oidc-gatekeeper",
-    channel="latest/edge",
+    channel="ckf-1.10/edge",
     trust=True,
 )
 TENSORBOARD_CONTROLLER = CharmSpec(
     charm="tensorboard-controller",
-    channel="latest/edge",
+    channel="1.11/edge",
     trust=True,
 )
 KUBEFLOW_VOLUMES = CharmSpec(
     charm="kubeflow-volumes",
-    channel="latest/edge",
+    channel="1.11/edge",
     trust=True,
 )


### PR DESCRIPTION
This PR pins the track of charm dependencies in tests.

### External (resolved via Terraform Solutions track/1.11 — fallback, no Solutions branch references this charm-repo track) — entries marked _(override)_ are pinned via `config.FALLBACK_OVERRIDES`
- `dex-auth`: `latest/edge` → `2.41/edge`
- `oidc-gatekeeper`: `latest/edge` → `ckf-1.10/edge`
- `tensorboard-controller`: `latest/edge` → `1.11/edge` _(override)_
- `kubeflow-volumes`: `latest/edge` → `1.11/edge` _(override)_

### Unresolved (left unchanged)
- `self-signed-certificates` (`latest/edge`) — self-signed-certificates not pinned in Solutions track/1.11 (fallback)

Refs: canonical/bundle-kubeflow#1379
