### PR TITLE
chore: remove lib checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,19 +55,6 @@ jobs:
               f.write(f"track={track}\n")
           
           print(f"Track: {track}")
-
-  lib-check:
-    name: Check libraries
-    needs:
-      - get-charm-paths-track
-    strategy:
-      matrix:
-        charm: ${{ fromJSON(needs.get-charm-paths-track.outputs.charm-paths) }}
-    uses: canonical/charmed-kubeflow-workflows/.github/workflows/_quality-checks.yaml@main
-    secrets: inherit
-    with:
-        charm-path: ${{ matrix.charm }}
-
   lint:
     name: Lint Code
     runs-on: ubuntu-24.04


### PR DESCRIPTION
This PR removes the `check lib` CI job which is no longer needed.

### Removed jobs
- `lib-check` in `.github/workflows/ci.yaml`

Refs: canonical/bundle-kubeflow#1439
